### PR TITLE
Optimize THCM

### DIFF
--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -52,7 +52,7 @@ extern "C" {
     _SUBROUTINE_(writeparams)();
     _SUBROUTINE_(rhs)(double*,double*);
     _SUBROUTINE_(setsres)(int *);
-    _SUBROUTINE_(matrix)(double*,double*,double*);
+    _SUBROUTINE_(matrix)(double*);
 
     // input:   n,m,l,nmlglob
     //          xmin,xmax,ymin,ymax,
@@ -971,12 +971,12 @@ bool THCM::evaluate(const Epetra_Vector& soln,
             FNAME(setsres)(&tmp_sres);
         }
 
-        FNAME(matrix)(solution,&sigmaUVTS,&sigmaWP);
+        FNAME(matrix)(solution);
 
         // Restore from the testing config
         if (maskTest)
             FNAME(setsres)(&sres);
-        
+
         TIMER_STOP("Ocean: compute jacobian: fortran part");
 
         const int maxlen = _NUN_*_NP_+1;    //nun*np+1 is max nonzeros per row

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -955,7 +955,7 @@ bool THCM::evaluate(const Epetra_Vector& soln,
         tmpJac->PutScalar(0.0); // set all matrix entries to zero
         localDiagB->PutScalar(0.0);
 
-        if (sigmaUVTS||(sigmaWP>1.0e-14)) {
+        if (sigmaUVTS || sigmaWP) {
             ERROR("We do not allow THCM to shift the matrix anymore!",
                   __FILE__,__LINE__);
         }

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -965,13 +965,17 @@ bool THCM::evaluate(const Epetra_Vector& soln,
         TIMER_START("Ocean: compute jacobian: fortran part");
 
         // If we test the mask we need non-restoring conditions in the matrix
-        int tmp_sres = (maskTest) ? 0 : sres;
-        FNAME(setsres)(&tmp_sres);
-        
+        if (maskTest)
+        {
+            int tmp_sres = 0;
+            FNAME(setsres)(&tmp_sres);
+        }
+
         FNAME(matrix)(solution,&sigmaUVTS,&sigmaWP);
 
         // Restore from the testing config
-        FNAME(setsres)(&sres);
+        if (maskTest)
+            FNAME(setsres)(&sres);
         
         TIMER_STOP("Ocean: compute jacobian: fortran part");
 

--- a/src/ocean/assemble.F90
+++ b/src/ocean/assemble.F90
@@ -9,7 +9,6 @@ SUBROUTINE assemble
   call fillcolA
   call intcond
 
-  call packA
   call TIMER_STOP('assemble' // char(0))
 
 end SUBROUTINE assemble
@@ -172,9 +171,6 @@ SUBROUTINE fillcolA
                        ! find_row2(i,j,k,ii) returns the row in the matrix for variable
                        !  ii at grid point (i,j,k) (matetc.F90)
                        jcoA(v) = find_row2(i2,j2,k2,jj)
-                       if (jcoA(v).lt.0) then
-                          write(*,*) i, j, k, i2, j2, k2, jj, jcoA(v)
-                          endif
                        v = v + 1
                     end if
                  end do
@@ -285,49 +281,6 @@ SUBROUTINE intcond
 
 
 end SUBROUTINE intcond
-
-!****************************************************************************
-SUBROUTINE packA
-  !     remove zero entries in A
-  USE m_mat
-  use m_usr
-  implicit none
-
-  integer vn,v,begin,i,oldsize
-  integer ii,jj,kk,XX,i2,j2,k2
-
-  call TIMER_START('packA' // char(0))
-
-  vn = 1
-  oldsize = begA(ndim+1) - 1
-  do i = 1, ndim
-     begin = vn
-     do v = begA(i), begA(i+1) - 1
-        if (abs(coA(v)).gt.1.0e-15) then
-           coA(vn)  =  coA(v)
-           jcoA(vn) = jcoA(v)
-           vn = vn + 1
-           if ((jcoA(v).gt.ndim).or.(jcoA(v).lt.0)) then
-              write(*,*) 'row = ', i, 'col = ', jcoA(v), 'entry = ', coA(v)
-              call findex(i,ii,jj,kk,XX)
-              write(*,*) 'row grid point (i,j,k):',ii,jj,kk
-              write(*,*) 'variable',XX
-              vn = mod(v-1,27)+1
-              call shift(ii,jj,kk,i2,j2,k2,vn)
-              write(*,*) 'col grid point (i,j,k):',i2,j2,k2
-              !                  call findex(jcoA(v),ii,jj,kk,XX)
-              !                  write(*,*) ii,jj,kk,XX
-              stop 'in packA: index out of range'
-           endif
-        endif
-     enddo
-     begA(i) = begin
-  enddo
-  begA(ndim+1) = vn
-
-  call TIMER_STOP('packA' // char(0))
-
-end SUBROUTINE packA
 
 !****************************************************************************
 SUBROUTINE dirset(row,Fd)

--- a/src/ocean/assemble.F90
+++ b/src/ocean/assemble.F90
@@ -291,47 +291,6 @@ SUBROUTINE shift(i,j,k,i2,j2,k2,np)
 end SUBROUTINE shift
 
 !****************************************************************************
-SUBROUTINE intcond_old
-  !     Impose integral condition
-  USE m_mat
-  use m_usr
-  implicit none
-  !      include 'mat.com'
-  integer find_row2
-  integer i, j, k, v, L1
-  !     Replace p equation at part. point with
-  !     a 'normalization' condition for p
-  !     L1 = nun*((L/2-1)*N*M+ N*(M/2-1) + N/2-1) + PP
-  L1 = find_row2(n,m,l,PP)
-  do v = begA(L1),begA(L1+1)-1
-     coA(v)= 0.0
-     if (jcoA(v).eq.L1) then
-        coA(v) = 1.0
-     endif
-  enddo
-  Frc(L1) = 0.0
-  !     Replace S equation at ndim with an 'integral' condition for s
-  do v = begA(ndim),begA(ndim+1)-1
-     coA(v) = 0.0
-  enddo
-
-  v = begA(ndim)
-  do k = 1, l
-     do j = 1, m
-        do i = 1, n
-           if ( landm(i,j,k) == OCEAN ) then
-              jcoA(v)= find_row2(i,j,k,SS)
-              coA(v) = cos(y(j)) * dfzT(k)
-              v = v+1
-           endif
-        enddo
-     enddo
-  enddo
-  begA(ndim+1) = v
-  Frc(ndim) =  0.0
-
-end SUBROUTINE intcond_old
-!****************************************************************************
 SUBROUTINE intcond
   !     Impose integral condition
   USE m_mat

--- a/src/ocean/assemble.F90
+++ b/src/ocean/assemble.F90
@@ -73,8 +73,8 @@ SUBROUTINE preprocessA
      do ii = 1,nun
         do jj = 1,nun
            do kk = 1,np
-              !                  if (abs(al(i,j,k,kk,ii,jj)) > 1.0E-14) then
-              if (al(i,j,k,kk,ii,jj) /= 0D0) then
+              !                  if (abs(an(i,j,k,kk,ii,jj)) > 1.0E-14) then
+              if (an(i,j,k,kk,ii,jj) /= 0D0) then
                  active(kk,ii,jj) = .true.
               end if
            end do
@@ -102,7 +102,7 @@ SUBROUTINE preprocessA_old
               do j = 1,m
                  do k = 1,l+la
                     ! --> 1.0E-10 small enough?
-                    if (abs(al(i,j,k,kk,ii,jj)) > 1.0E-10) then
+                    if (abs(an(i,j,k,kk,ii,jj)) > 1.0E-10) then
                        active(kk,ii,jj) = .true.
                        cycle loop
                     end if
@@ -203,7 +203,7 @@ SUBROUTINE fillcolA
                  do jj = 1, nun
                     if (active(kk,ii,jj)) then
                        w = v + (jj-1)*np ! ? grouped ordering?                       
-                       coA(w+kk)  = al(i,j,k,kk,ii,jj)
+                       coA(w+kk)  = an(i,j,k,kk,ii,jj)
                        jcoA(w+kk) = find_row2(i2,j2,k2,jj)
                     end if
                  end do

--- a/src/ocean/assemble.F90
+++ b/src/ocean/assemble.F90
@@ -151,14 +151,12 @@ SUBROUTINE fillcolA
   ! |     is stored in the row corresponding to ii|(i,j,k) and the column         |
   ! |     corresponding to jj|(i2,j2,k2).                                         |
   ! +-----------------------------------------------------------------------------+
-  ! begA = 0
-  coA = 0.0
+  begA = 0
   v = 1
   row = 1
   do k = 1, l+la
      do j = 1, m
         do i = 1, n
-
            do ii = 1, nun
               begA(row) = v
               do kk = 1,np
@@ -219,7 +217,11 @@ SUBROUTINE shift(i,j,k,i2,j2,k2,kk)
   end if
 
   if (periodic) then
-     i2 = mod(i2-1+n,n)+1
+     if (i2.eq.0) then
+        i2 = n
+     elseif (i2.eq.(n+1)) then
+        i2 = 1
+     endif
   endif
 
 end SUBROUTINE shift

--- a/src/ocean/assemble.F90
+++ b/src/ocean/assemble.F90
@@ -25,6 +25,8 @@ SUBROUTINE fillcolB
   integer find_row2
   integer i,j,k
 
+  call TIMER_START('fillcolB' // char(0))
+
   !     Put B in coB,  B is a diagonal matrix.
   !     PRINT *,'parROSB = ',par(ROSB)
   coB = 0.0
@@ -54,6 +56,8 @@ SUBROUTINE fillcolB
      ! if(SRES == 0) coB(rowintcon + SS) = 0.0 !zero in B for integral condition
      if(SRES == 0) coB(rowintcon) = 0.0 !zero in B for integral condition
   end if
+
+  call TIMER_STOP('fillcolB' // char(0))
 
 end SUBROUTINE fillcolB
 

--- a/src/ocean/boundary.F90
+++ b/src/ocean/boundary.F90
@@ -16,6 +16,8 @@ subroutine boundaries
   integer southee, easteast, northee, nnwest, nnorth, nneast
   integer nnorthee
 
+  call TIMER_START('boundaries' // char(0))
+
   !  new stencil:
   !    +----------++-------++----------+
   !    | 12 15 18 || 3 6 9 || 21 24 27 |
@@ -81,54 +83,54 @@ subroutine boundaries
               ! on mirror/boundary points
               if (bottom == LAND) then  ! 14
                  if ((westb==LAND).and.(southwb==LAND).and.(southb==LAND)) then
-                    An(i,j,k, 1,: ,UU) = An(i,j,k,1,: ,UU) + An(i,j,k,10,: ,UU) ! ACdN
-                    An(i,j,k, 1,: ,VV) = An(i,j,k,1,: ,VV) + An(i,j,k,10,: ,VV) ! ACdN
+                    An( 1,: ,UU,i,j,k) = An(1,: ,UU,i,j,k) + An(10,: ,UU,i,j,k) ! ACdN
+                    An( 1,: ,VV,i,j,k) = An(1,: ,VV,i,j,k) + An(10,: ,VV,i,j,k) ! ACdN
                  endif
-                 An(i,j,k,10,: ,UU) = 0.0
-                 An(i,j,k,10,: ,VV) = 0.0
+                 An(10,: ,UU,i,j,k) = 0.0
+                 An(10,: ,VV,i,j,k) = 0.0
                  if ((westb==LAND).and.(neastb==LAND).and.(northb==LAND)) then
-                    An(i,j,k, 2,: ,UU) = An(i,j,k,2,: ,UU) + An(i,j,k,11,: ,UU) ! ACdN
-                    An(i,j,k, 2,: ,VV) = An(i,j,k,2,: ,VV) + An(i,j,k,11,: ,VV) ! ACdN
+                    An( 2,: ,UU,i,j,k) = An(2,: ,UU,i,j,k) + An(11,: ,UU,i,j,k) ! ACdN
+                    An( 2,: ,VV,i,j,k) = An(2,: ,VV,i,j,k) + An(11,: ,VV,i,j,k) ! ACdN
                  endif
-                 An(i,j,k,11,: ,UU) = 0.0 !ACdN
-                 An(i,j,k,11,: ,VV) = 0.0 !ACdN
+                 An(11,: ,UU,i,j,k) = 0.0 !ACdN
+                 An(11,: ,VV,i,j,k) = 0.0 !ACdN
                  if ((eastb==LAND).and.(southeb==LAND).and.(southb==LAND)) then
-                    An(i,j,k, 4,: ,UU) = An(i,j,k,4,: ,UU) + An(i,j,k,13,: ,UU) ! ACdN
-                    An(i,j,k, 4,: ,VV) = An(i,j,k,4,: ,VV) + An(i,j,k,13,: ,VV) ! ACdN
+                    An( 4,: ,UU,i,j,k) = An(4,: ,UU,i,j,k) + An(13,: ,UU,i,j,k) ! ACdN
+                    An( 4,: ,VV,i,j,k) = An(4,: ,VV,i,j,k) + An(13,: ,VV,i,j,k) ! ACdN
                  endif
-                 An(i,j,k,13,: ,UU) = 0.0 !ACdN
-                 An(i,j,k,13,: ,VV) = 0.0 !ACdN
+                 An(13,: ,UU,i,j,k) = 0.0 !ACdN
+                 An(13,: ,VV,i,j,k) = 0.0 !ACdN
                  if ((eastb==LAND).and.(neastb==LAND).and.(northb==LAND)) then
-                    An(i,j,k, 5,: ,UU) = An(i,j,k,5,: ,UU) + An(i,j,k,14,: ,UU) ! ACdN
-                    An(i,j,k, 5,: ,VV) = An(i,j,k,5,: ,VV) + An(i,j,k,14,: ,VV) ! ACdN
+                    An( 5,: ,UU,i,j,k) = An(5,: ,UU,i,j,k) + An(14,: ,UU,i,j,k) ! ACdN
+                    An( 5,: ,VV,i,j,k) = An(5,: ,VV,i,j,k) + An(14,: ,VV,i,j,k) ! ACdN
                  endif
-                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,14,: ,TT) ! ACdN
-                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,14,: ,SS) ! ACdN
-                 An(i,j,k,14,: ,: ) = 0.0
+                 An( 5,: ,TT,i,j,k) = An(5,: ,TT,i,j,k) + An(14,: ,TT,i,j,k) ! ACdN
+                 An( 5,: ,SS,i,j,k) = An(5,: ,SS,i,j,k) + An(14,: ,SS,i,j,k) ! ACdN
+                 An(14,: ,: ,i,j,k) = 0.0
               endif
               if (southwb == LAND) then ! 10
-                 An(i,j,k,10,: ,: ) = 0.0
+                 An(10,: ,: ,i,j,k) = 0.0
               endif
               if (westb == LAND) then   ! 11
-                 An(i,j,k,11,: ,: ) = 0.0
+                 An(11,: ,: ,i,j,k) = 0.0
               endif
               if (nwestb == LAND) then  ! 12
-                 An(i,j,k,12,: ,: ) = 0.0
+                 An(12,: ,: ,i,j,k) = 0.0
               endif
               if (southb == LAND) then  ! 13
-                 An(i,j,k,13,: ,:)   = 0.0
+                 An(13,: ,:,i,j,k)   = 0.0
               endif
               if (northb == LAND) then  ! 15
-                 An(i,j,k,15,: ,:)  = 0.0
+                 An(15,: ,:,i,j,k)  = 0.0
               endif
               if (southeb == LAND) then ! 16
-                 An(i,j,k,16,: ,:)  = 0.0
+                 An(16,: ,:,i,j,k)  = 0.0
               endif
               if (eastb == LAND) then   ! 17
-                 An(i,j,k,17,: ,:)  = 0.0
+                 An(17,: ,:,i,j,k)  = 0.0
               endif
               if (neastb == LAND) then  ! 18
-                 An(i,j,k,18,: ,:)  = 0.0
+                 An(18,: ,:,i,j,k)  = 0.0
               endif
               if (top == LAND) then ! 23
                  ! cannot occur in real flow domain, LAND above OCEAN is illegal
@@ -137,229 +139,230 @@ subroutine boundaries
                     write(f99,*) i,j,k, landm(i  ,j  ,k),landm(i  ,j  ,k+1)
                  endif
                  if ((westt==LAND).and.(southwt==LAND).and.(southt==LAND)) then
-                    An(i,j,k, 1,: ,UU) = An(i,j,k,1,: ,UU) + An(i,j,k,19,: ,UU) ! ACdN
-                    An(i,j,k, 1,: ,VV) = An(i,j,k,1,: ,VV) + An(i,j,k,19,: ,VV) ! ACdN
+                    An( 1,: ,UU,i,j,k) = An(1,: ,UU,i,j,k) + An(19,: ,UU,i,j,k) ! ACdN
+                    An( 1,: ,VV,i,j,k) = An(1,: ,VV,i,j,k) + An(19,: ,VV,i,j,k) ! ACdN
                  endif
-                 An(i,j,k,19,: ,UU) = 0.0
-                 An(i,j,k,19,: ,VV) = 0.0
+                 An(19,: ,UU,i,j,k) = 0.0
+                 An(19,: ,VV,i,j,k) = 0.0
                  if ((westt==LAND).and.(nwestt==LAND).and.(northt==LAND)) then
-                    An(i,j,k, 2,: ,UU) = An(i,j,k,2,: ,UU) + An(i,j,k,20,: ,UU) ! ACdN
-                    An(i,j,k, 2,: ,VV) = An(i,j,k,2,: ,VV) + An(i,j,k,20,: ,VV) ! ACdN
+                    An( 2,: ,UU,i,j,k) = An(2,: ,UU,i,j,k) + An(20,: ,UU,i,j,k) ! ACdN
+                    An( 2,: ,VV,i,j,k) = An(2,: ,VV,i,j,k) + An(20,: ,VV,i,j,k) ! ACdN
                  endif
-                 An(i,j,k,20,: ,UU) = 0.0 !ACdN
-                 An(i,j,k,20,: ,VV) = 0.0 !ACdN
+                 An(20,: ,UU,i,j,k) = 0.0 !ACdN
+                 An(20,: ,VV,i,j,k) = 0.0 !ACdN
                  if ((eastt==LAND).and.(southet==LAND).and.(southt==LAND)) then
-                    An(i,j,k, 4,: ,UU) = An(i,j,k,4,: ,UU) + An(i,j,k,22,: ,UU) ! ACdN
-                    An(i,j,k, 4,: ,VV) = An(i,j,k,4,: ,VV) + An(i,j,k,22,: ,VV) ! ACdN
+                    An( 4,: ,UU,i,j,k) = An(4,: ,UU,i,j,k) + An(22,: ,UU,i,j,k) ! ACdN
+                    An( 4,: ,VV,i,j,k) = An(4,: ,VV,i,j,k) + An(22,: ,VV,i,j,k) ! ACdN
                  endif
-                 An(i,j,k,22,: ,UU) = 0.0 !ACdN
-                 An(i,j,k,22,: ,VV) = 0.0 !ACdN
+                 An(22,: ,UU,i,j,k) = 0.0 !ACdN
+                 An(22,: ,VV,i,j,k) = 0.0 !ACdN
                  if ((eastt==LAND).and.(neastt==LAND).and.(northt==LAND)) then
-                    An(i,j,k, 5,: ,UU) = An(i,j,k,5,: ,UU) + An(i,j,k,23,: ,UU) ! ACdN
-                    An(i,j,k, 5,: ,VV) = An(i,j,k,5,: ,VV) + An(i,j,k,23,: ,VV) ! ACdN
+                    An( 5,: ,UU,i,j,k) = An(5,: ,UU,i,j,k) + An(23,: ,UU,i,j,k) ! ACdN
+                    An( 5,: ,VV,i,j,k) = An(5,: ,VV,i,j,k) + An(23,: ,VV,i,j,k) ! ACdN
                  endif
-                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,23,: ,TT) ! ACdN
-                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,23,: ,SS) ! ACdN
-                 An(i,j,k,23,: ,: ) = 0.0
+                 An( 5,: ,TT,i,j,k) = An(5,: ,TT,i,j,k) + An(23,: ,TT,i,j,k) ! ACdN
+                 An( 5,: ,SS,i,j,k) = An(5,: ,SS,i,j,k) + An(23,: ,SS,i,j,k) ! ACdN
+                 An(23,: ,: ,i,j,k) = 0.0
 
                  Frc(find_row2(i,j,k,WW)) = 0.0
-                 An(i,j,k, :,WW,: ) = 0.0
+
+                 An( :,WW,: ,i,j,k) = 0.0
                  ! FIXME preconditioner breakdown if we remove the
                  ! connections, hence we try to maintain the
                  ! connection but make it inactive with 1e-10
-                 An(i,j,k, 5, :,WW) = 1.0e-10 !MdT !TEM
-                 An(i,j,k, 6, :,WW) = 1.0e-10 !MdT !TEM
-                 An(i,j,k, 8, :,WW) = 1.0e-10 !MdT !TEM
-                 An(i,j,k, 9, :,WW) = 1.0e-10 !MdT !TEM
-                 An(i,j,k, 5,WW,WW) = 1.0
+                 An( 5, :,WW,i,j,k) = 1.0e-10 !MdT !TEM
+                 An( 6, :,WW,i,j,k) = 1.0e-10 !MdT !TEM
+                 An( 8, :,WW,i,j,k) = 1.0e-10 !MdT !TEM
+                 An( 9, :,WW,i,j,k) = 1.0e-10 !MdT !TEM
+                 An( 5,WW,WW,i,j,k) = 1.0
 
               endif
               if (top == ATMOS) then ! deprecated in i-emic
-                 An(i,j,k, 1,: ,UU) = An(i,j,k,1,: ,UU) + An(i,j,k,19,: ,UU) ! ACdN
-                 An(i,j,k, 1,: ,VV) = An(i,j,k,1,: ,VV) + An(i,j,k,19,: ,VV) ! ACdN
-                 An(i,j,k,19,: ,UU) = 0.0
-                 An(i,j,k,19,: ,VV) = 0.0
-                 An(i,j,k, 2,: ,UU) = An(i,j,k,2,: ,UU) + An(i,j,k,20,: ,UU) ! ACdN
-                 An(i,j,k, 2,: ,VV) = An(i,j,k,2,: ,VV) + An(i,j,k,20,: ,VV) ! ACdN
-                 An(i,j,k,20,: ,UU) = 0.0 !ACdN
-                 An(i,j,k,20,: ,VV) = 0.0 !ACdN
-                 An(i,j,k, 4,: ,UU) = An(i,j,k,4,: ,UU) + An(i,j,k,22,: ,UU) ! ACdN
-                 An(i,j,k, 4,: ,VV) = An(i,j,k,4,: ,VV) + An(i,j,k,22,: ,VV) ! ACdN
-                 An(i,j,k,22,: ,UU) = 0.0 !ACdN
-                 An(i,j,k,22,: ,VV) = 0.0 !ACdN
-                 An(i,j,k, 5,: ,UU) = An(i,j,k,5,: ,UU) + An(i,j,k,23,: ,UU) ! ACdN
-                 An(i,j,k, 5,: ,VV) = An(i,j,k,5,: ,VV) + An(i,j,k,23,: ,VV) ! ACdN
-                 An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,23,SS,SS)
-                 An(i,j,k,23,SS,SS) = 0.0
+                 An( 1,: ,UU,i,j,k) = An(1,: ,UU,i,j,k) + An(19,: ,UU,i,j,k) ! ACdN
+                 An( 1,: ,VV,i,j,k) = An(1,: ,VV,i,j,k) + An(19,: ,VV,i,j,k) ! ACdN
+                 An(19,: ,UU,i,j,k) = 0.0
+                 An(19,: ,VV,i,j,k) = 0.0
+                 An( 2,: ,UU,i,j,k) = An(2,: ,UU,i,j,k) + An(20,: ,UU,i,j,k) ! ACdN
+                 An( 2,: ,VV,i,j,k) = An(2,: ,VV,i,j,k) + An(20,: ,VV,i,j,k) ! ACdN
+                 An(20,: ,UU,i,j,k) = 0.0 !ACdN
+                 An(20,: ,VV,i,j,k) = 0.0 !ACdN
+                 An( 4,: ,UU,i,j,k) = An(4,: ,UU,i,j,k) + An(22,: ,UU,i,j,k) ! ACdN
+                 An( 4,: ,VV,i,j,k) = An(4,: ,VV,i,j,k) + An(22,: ,VV,i,j,k) ! ACdN
+                 An(22,: ,UU,i,j,k) = 0.0 !ACdN
+                 An(22,: ,VV,i,j,k) = 0.0 !ACdN
+                 An( 5,: ,UU,i,j,k) = An(5,: ,UU,i,j,k) + An(23,: ,UU,i,j,k) ! ACdN
+                 An( 5,: ,VV,i,j,k) = An(5,: ,VV,i,j,k) + An(23,: ,VV,i,j,k) ! ACdN
+                 An( 5,SS,SS,i,j,k) = An(5,SS,SS,i,j,k) + An(23,SS,SS,i,j,k)
+                 An(23,SS,SS,i,j,k) = 0.0
 
                  Frc(find_row2(i,j,k,WW)) = 0.0
-                 An(i,j,k, :,WW,: ) = 0.0
+                 An( :,WW,: ,i,j,k) = 0.0
                  ! preconditioner breakdown if we do this:
-                 ! An(i,j,k, 5, :,WW) = 0.0 ! 1.0e-10 !MdT
-                 ! An(i,j,k, 6, :,WW) = 0.0 ! 1.0e-10 !MdT
-                 ! An(i,j,k, 8, :,WW) = 0.0 ! 1.0e-10 !MdT
-                 ! An(i,j,k, 9, :,WW) = 0.0 ! 1.0e-10 !MdT
-                 An(i,j,k, 5,WW,WW) = 1.0
+                 ! An( 5, :,WW,i,j,k) = 0.0 ! 1.0e-10 !MdT
+                 ! An( 6, :,WW,i,j,k) = 0.0 ! 1.0e-10 !MdT
+                 ! An( 8, :,WW,i,j,k) = 0.0 ! 1.0e-10 !MdT
+                 ! An( 9, :,WW,i,j,k) = 0.0 ! 1.0e-10 !MdT
+                 An( 5,WW,WW,i,j,k) = 1.0
 
               endif
               !     if (southwt == LAND) then   ! 19
               if ((southwt == LAND).OR.(southwt ==ATMOS)) then  ! 19
-                 An(i,j,k,19,: ,:)  = 0.0
+                 An(19,: ,:,i,j,k)  = 0.0
               endif
               !     if (westt == LAND) then     ! 20
               if ((westt == LAND).OR.(westt == ATMOS)) then     ! 20
-                 An(i,j,k,20,: ,: ) = 0.0
+                 An(20,: ,: ,i,j,k) = 0.0
               endif
               if ((nwestt == LAND).OR.(nwestt == ATMOS)) then   ! 21
-                 An(i,j,k,21,:,:)    = 0.0
+                 An(21,:,:,i,j,k)    = 0.0
               endif
               if ((southt == LAND).OR.(southt == ATMOS)) then   ! 22
-                 An(i,j,k,22,: ,:)   = 0.0
+                 An(22,: ,:,i,j,k)   = 0.0
               endif
               if ((northt == LAND).OR.(northt == ATMOS)) then   ! 24
-                 An(i,j,k,24,: ,:)  = 0.0
+                 An(24,: ,:,i,j,k)  = 0.0
               endif
               if ((southet == LAND).OR.(southet == ATMOS)) then ! 25
-                 An(i,j,k,25,: ,:)  = 0.0
+                 An(25,: ,:,i,j,k)  = 0.0
               endif
               if ((eastt == LAND).OR.(eastt == ATMOS)) then     ! 26
-                 An(i,j,k,26,: ,:)  = 0.0
+                 An(26,: ,:,i,j,k)  = 0.0
               endif
               if ((neastt == LAND).OR.(neastt == ATMOS)) then   ! 27
-                 An(i,j,k,27,: ,:)  = 0.0
+                 An(27,: ,:,i,j,k)  = 0.0
               endif
               if (southw == LAND) then  ! 1
-                 An(i,j,k, 1,: ,UU) = 0.0
-                 An(i,j,k, 1,: ,VV) = 0.0
+                 An( 1,: ,UU,i,j,k) = 0.0
+                 An( 1,: ,VV,i,j,k) = 0.0
               endif
               if (west == LAND) then    ! 2
-                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,2,: ,TT) ! ACdN
-                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,2,: ,SS) ! ACdN
-                 !              An(i,j,k, 5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,2,TT,TT)
-                 !              An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,2,SS,SS)
-                 !              An(i,j,k, 5,TT,SS) = An(i,j,k,5,TT,SS) + An(i,j,k,2,TT,SS)
-                 !              An(i,j,k, 5,SS,TT) = An(i,j,k,5,SS,TT) + An(i,j,k,2,SS,TT)
-                 An(i,j,k, 2,: ,: ) = 0.0
-                 An(i,j,k, 1,: ,UU) = 0.0
-                 An(i,j,k, 1,: ,VV) = 0.0
+                 An( 5,: ,TT,i,j,k) = An(5,: ,TT,i,j,k) + An(2,: ,TT,i,j,k) ! ACdN
+                 An( 5,: ,SS,i,j,k) = An(5,: ,SS,i,j,k) + An(2,: ,SS,i,j,k) ! ACdN
+                 !              An( 5,TT,TT,i,j,k) = An(5,TT,TT,i,j,k) + An(2,TT,TT,i,j,k)
+                 !              An( 5,SS,SS,i,j,k) = An(5,SS,SS,i,j,k) + An(2,SS,SS,i,j,k)
+                 !              An( 5,TT,SS,i,j,k) = An(5,TT,SS,i,j,k) + An(2,TT,SS,i,j,k)
+                 !              An( 5,SS,TT,i,j,k) = An(5,SS,TT,i,j,k) + An(2,SS,TT,i,j,k)
+                 An( 2,: ,: ,i,j,k) = 0.0
+                 An( 1,: ,UU,i,j,k) = 0.0
+                 An( 1,: ,VV,i,j,k) = 0.0
               endif
               if (nwest == LAND) then   ! 3
-                 An(i,j,k, 2,: ,UU) = 0.0
-                 An(i,j,k, 2,: ,VV) = 0.0
-                 An(i,j,k, 3,: ,UU) = 0.0
-                 An(i,j,k, 3,: ,VV) = 0.0
+                 An( 2,: ,UU,i,j,k) = 0.0
+                 An( 2,: ,VV,i,j,k) = 0.0
+                 An( 3,: ,UU,i,j,k) = 0.0
+                 An( 3,: ,VV,i,j,k) = 0.0
               elseif (j.lt.m) then
                  if (nnwest == LAND) then
-                    An(i,j,k, 3,: ,UU) = 0.0
-                    An(i,j,k, 3,: ,VV) = 0.0
+                    An( 3,: ,UU,i,j,k) = 0.0
+                    An( 3,: ,VV,i,j,k) = 0.0
                  endif
               endif
               if (south == LAND) then   ! 4
-                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,4,: ,SS) ! ACdN
-                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,4,: ,TT) ! ACdN
-                 !   An(i,j,k, 5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,4,TT,TT)
-                 !   An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,4,SS,SS)
-                 !   An(i,j,k, 5,TT,SS) = An(i,j,k,5,TT,SS) + An(i,j,k,4,TT,SS)
-                 !   An(i,j,k, 5,SS,TT) = An(i,j,k,5,SS,TT) + An(i,j,k,4,SS,TT)
-                 An(i,j,k, 4,: ,: ) = 0.0
-                 An(i,j,k, 1,: ,UU) = 0.0
-                 An(i,j,k, 1,: ,VV) = 0.0
+                 An( 5,: ,SS,i,j,k) = An(5,: ,SS,i,j,k) + An(4,: ,SS,i,j,k) ! ACdN
+                 An( 5,: ,TT,i,j,k) = An(5,: ,TT,i,j,k) + An(4,: ,TT,i,j,k) ! ACdN
+                 !   An( 5,TT,TT,i,j,k) = An(5,TT,TT,i,j,k) + An(4,TT,TT,i,j,k)
+                 !   An( 5,SS,SS,i,j,k) = An(5,SS,SS,i,j,k) + An(4,SS,SS,i,j,k)
+                 !   An( 5,TT,SS,i,j,k) = An(5,TT,SS,i,j,k) + An(4,TT,SS,i,j,k)
+                 !   An( 5,SS,TT,i,j,k) = An(5,SS,TT,i,j,k) + An(4,SS,TT,i,j,k)
+                 An( 4,: ,: ,i,j,k) = 0.0
+                 An( 1,: ,UU,i,j,k) = 0.0
+                 An( 1,: ,VV,i,j,k) = 0.0
               endif
               if (north == LAND) then   ! 6
-                 An(i,j,k, 2,: ,UU) = 0.0
-                 An(i,j,k, 2,: ,VV) = 0.0
+                 An( 2,: ,UU,i,j,k) = 0.0
+                 An( 2,: ,VV,i,j,k) = 0.0
                  !
                  ! continuity
                  !
-                 An(i,j,k, 2,PP,UU) = 0.0
-                 An(i,j,k, 2,PP,VV) = 0.0
-                 An(i,j,k, 5,PP,UU) = 0.0
-                 An(i,j,k, 5,PP,VV) = 0.0
+                 An( 2,PP,UU,i,j,k) = 0.0
+                 An( 2,PP,VV,i,j,k) = 0.0
+                 An( 5,PP,UU,i,j,k) = 0.0
+                 An( 5,PP,VV,i,j,k) = 0.0
                  !
                  ! theta momentum
                  !
                  Frc(find_row2(i,j,k,VV)) = 0.0
-                 An(i,j,k, :,VV,: ) = 0.0
-                 An(i,j,k, 5,: ,VV) = 0.0 ! ACdN
-                 An(i,j,k, 5,VV,VV) = 1.0
+                 An( :,VV,: ,i,j,k) = 0.0
+                 An( 5,: ,VV,i,j,k) = 0.0 ! ACdN
+                 An( 5,VV,VV,i,j,k) = 1.0
                  !
                  ! phi momentum
                  !
                  Frc(find_row2(i,j,k,UU)) = 0.0
-                 An(i,j,k, :,UU, :) = 0.0
-                 An(i,j,k, 5,: ,UU) = 0.0 ! ACdN
-                 An(i,j,k, 5,UU,UU) = 1.0
+                 An( :,UU, :,i,j,k) = 0.0
+                 An( 5,: ,UU,i,j,k) = 0.0 ! ACdN
+                 An( 5,UU,UU,i,j,k) = 1.0
                  !
                  ! tracers
                  !
-                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,6,: ,SS) ! ACdN
-                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,6,: ,TT) ! ACdN
-                 !   An(i,j,k, 5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,6,TT,TT)
-                 !   An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,6,SS,SS)
-                 !   An(i,j,k, 5,TT,SS) = An(i,j,k,5,TT,SS) + An(i,j,k,6,TT,SS)
-                 !   An(i,j,k, 5,SS,TT) = An(i,j,k,5,SS,TT) + An(i,j,k,6,SS,TT)
-                 An(i,j,k, 6,: ,: ) = 0.0
+                 An( 5,: ,SS,i,j,k) = An(5,: ,SS,i,j,k) + An(6,: ,SS,i,j,k) ! ACdN
+                 An( 5,: ,TT,i,j,k) = An(5,: ,TT,i,j,k) + An(6,: ,TT,i,j,k) ! ACdN
+                 !   An( 5,TT,TT,i,j,k) = An(5,TT,TT,i,j,k) + An(6,TT,TT,i,j,k)
+                 !   An( 5,SS,SS,i,j,k) = An(5,SS,SS,i,j,k) + An(6,SS,SS,i,j,k)
+                 !   An( 5,TT,SS,i,j,k) = An(5,TT,SS,i,j,k) + An(6,TT,SS,i,j,k)
+                 !   An( 5,SS,TT,i,j,k) = An(5,SS,TT,i,j,k) + An(6,SS,TT,i,j,k)
+                 An( 6,: ,: ,i,j,k) = 0.0
               elseif (j.lt.m) then
                  if (nnorth == LAND) then
-                    An(i,j,k, 3,: ,UU) = 0.0
-                    An(i,j,k, 3,: ,VV) = 0.0
-                    An(i,j,k, 6,: ,UU) = 0.0
-                    An(i,j,k, 6,: ,VV) = 0.0
+                    An( 3,: ,UU,i,j,k) = 0.0
+                    An( 3,: ,VV,i,j,k) = 0.0
+                    An( 6,: ,UU,i,j,k) = 0.0
+                    An( 6,: ,VV,i,j,k) = 0.0
                  endif
               endif
               if (southe == LAND) then  ! 7
-                 An(i,j,k, 4, :,UU) = 0.0
-                 An(i,j,k, 4, :,VV) = 0.0
-                 An(i,j,k, 7, :,UU) = 0.0
-                 An(i,j,k, 7, :,VV) = 0.0
+                 An( 4, :,UU,i,j,k) = 0.0
+                 An( 4, :,VV,i,j,k) = 0.0
+                 An( 7, :,UU,i,j,k) = 0.0
+                 An( 7, :,VV,i,j,k) = 0.0
               elseif (i.lt.n) then
                  if (southee == LAND) then
-                    An(i,j,k, 7,: ,UU) = 0.0
-                    An(i,j,k, 7,: ,VV) = 0.0
+                    An( 7,: ,UU,i,j,k) = 0.0
+                    An( 7,: ,VV,i,j,k) = 0.0
                  endif
               endif
               if (east == LAND) then    ! 8
-                 An(i,j,k, 4,: ,UU) = 0.0
-                 An(i,j,k, 4,: ,VV) = 0.0
+                 An( 4,: ,UU,i,j,k) = 0.0
+                 An( 4,: ,VV,i,j,k) = 0.0
                  !
                  ! continuity
                  !
-                 An(i,j,k, 4,PP,UU) = 0.0
-                 An(i,j,k, 4,PP,VV) = 0.0
-                 An(i,j,k, 5,PP,UU) = 0.0
-                 An(i,j,k, 5,PP,VV) = 0.0
+                 An( 4,PP,UU,i,j,k) = 0.0
+                 An( 4,PP,VV,i,j,k) = 0.0
+                 An( 5,PP,UU,i,j,k) = 0.0
+                 An( 5,PP,VV,i,j,k) = 0.0
                  !
                  ! phi momentum
                  !
                  Frc(find_row2(i,j,k,UU)) = 0.0
-                 An(i,j,k, :,UU,: ) = 0.0
-                 An(i,j,k, 5,: ,UU) = 0.0 ! ACdN
-                 An(i,j,k, 5,UU,UU) = 1.0
+                 An( :,UU,: ,i,j,k) = 0.0
+                 An( 5,: ,UU,i,j,k) = 0.0 ! ACdN
+                 An( 5,UU,UU,i,j,k) = 1.0
                  !
                  ! theta momentum
                  !
                  Frc(find_row2(i,j,k,VV)) = 0.0
-                 An(i,j,k, :,VV, :) = 0.0
-                 An(i,j,k, 5,: ,VV) = 0.0 ! ACdN
-                 An(i,j,k, 5,VV,VV) = 1.0
+                 An( :,VV, :,i,j,k) = 0.0
+                 An( 5,: ,VV,i,j,k) = 0.0 ! ACdN
+                 An( 5,VV,VV,i,j,k) = 1.0
                  !
                  ! tracers
                  !
-                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,8,: ,SS)
-                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,8,: ,TT)
-                 !   An(i,j,k, 5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,8,TT,TT)
-                 !   An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,8,SS,SS)
-                 !   An(i,j,k, 5,TT,SS) = An(i,j,k,5,TT,SS) + An(i,j,k,8,TT,SS)
-                 !   An(i,j,k, 5,SS,TT) = An(i,j,k,5,SS,TT) + An(i,j,k,8,SS,TT)
-                 An(i,j,k, 8,: ,: ) = 0.0
-                 An(i,j,k, 7, :,UU) = 0.0
-                 An(i,j,k, 7, :,VV) = 0.0
+                 An( 5,: ,SS,i,j,k) = An(5,: ,SS,i,j,k) + An(8,: ,SS,i,j,k)
+                 An( 5,: ,TT,i,j,k) = An(5,: ,TT,i,j,k) + An(8,: ,TT,i,j,k)
+                 !   An( 5,TT,TT,i,j,k) = An(5,TT,TT,i,j,k) + An(8,TT,TT,i,j,k)
+                 !   An( 5,SS,SS,i,j,k) = An(5,SS,SS,i,j,k) + An(8,SS,SS,i,j,k)
+                 !   An( 5,TT,SS,i,j,k) = An(5,TT,SS,i,j,k) + An(8,TT,SS,i,j,k)
+                 !   An( 5,SS,TT,i,j,k) = An(5,SS,TT,i,j,k) + An(8,SS,TT,i,j,k)
+                 An( 8,: ,: ,i,j,k) = 0.0
+                 An( 7, :,UU,i,j,k) = 0.0
+                 An( 7, :,VV,i,j,k) = 0.0
               elseif (i.lt.n) then
                  if (easteast == LAND) then
-                    An(i,j,k, 7,: ,UU) = 0.0
-                    An(i,j,k, 7,: ,VV) = 0.0
-                    An(i,j,k, 8,: ,UU) = 0.0
-                    An(i,j,k, 8,: ,VV) = 0.0
+                    An( 7,: ,UU,i,j,k) = 0.0
+                    An( 7,: ,VV,i,j,k) = 0.0
+                    An( 8,: ,UU,i,j,k) = 0.0
+                    An( 8,: ,VV,i,j,k) = 0.0
                  endif
               endif
               if (neast == LAND) then   ! 9
@@ -367,38 +370,38 @@ subroutine boundaries
                  ! phi momentum
                  !
                  Frc(find_row2(i,j,k,UU)) = 0.0
-                 An(i,j,k, :,UU,: ) = 0.0
-                 An(i,j,k, 5,: ,UU) = 0.0
-                 An(i,j,k, 5,UU,UU) = 1.0
+                 An( :,UU,: ,i,j,k) = 0.0
+                 An( 5,: ,UU,i,j,k) = 0.0
+                 An( 5,UU,UU,i,j,k) = 1.0
                  !
                  ! theta momentum
                  !
                  Frc(find_row2(i,j,k,VV)) = 0.0
-                 An(i,j,k, :,VV,: ) = 0.0
-                 An(i,j,k, 5,: ,VV) = 0.0
-                 An(i,j,k, 5,VV,VV) = 1.0
-                 An(i,j,k, 7, :,UU) = 0.0
-                 An(i,j,k, 7, :,VV) = 0.0
+                 An( :,VV,: ,i,j,k) = 0.0
+                 An( 5,: ,VV,i,j,k) = 0.0
+                 An( 5,VV,VV,i,j,k) = 1.0
+                 An( 7, :,UU,i,j,k) = 0.0
+                 An( 7, :,VV,i,j,k) = 0.0
               elseif ((i.lt.n).or.(j.lt.m)) then
                  if (i.lt.n) then
                     if (northee == LAND) then
-                       An(i,j,k, 8,: ,UU) = 0.0
-                       An(i,j,k, 8,: ,VV) = 0.0
-                       An(i,j,k, 9,: ,UU) = 0.0
-                       An(i,j,k, 9,: ,VV) = 0.0
+                       An( 8,: ,UU,i,j,k) = 0.0
+                       An( 8,: ,VV,i,j,k) = 0.0
+                       An( 9,: ,UU,i,j,k) = 0.0
+                       An( 9,: ,VV,i,j,k) = 0.0
                     elseif (j.lt.m) then
                        if (nnorthee == LAND) then
-                          An(i,j,k, 9,: ,UU) = 0.0
-                          An(i,j,k, 9,: ,VV) = 0.0
+                          An( 9,: ,UU,i,j,k) = 0.0
+                          An( 9,: ,VV,i,j,k) = 0.0
                        endif
                     endif
                  endif
                  if (j.lt.m) then
                     if (nneast == LAND) then
-                       An(i,j,k, 6,: ,UU) = 0.0
-                       An(i,j,k, 6,: ,VV) = 0.0
-                       An(i,j,k, 9,: ,UU) = 0.0
-                       An(i,j,k, 9,: ,VV) = 0.0
+                       An( 6,: ,UU,i,j,k) = 0.0
+                       An( 6,: ,VV,i,j,k) = 0.0
+                       An( 9,: ,UU,i,j,k) = 0.0
+                       An( 9,: ,VV,i,j,k) = 0.0
                     endif
                  endif
               endif
@@ -406,31 +409,33 @@ subroutine boundaries
            else if (center == ATMOS) then
               write(*,*) 'center is atmos'
               if (west == LAND) then
-                 An(i,j,k,5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,2,TT,TT)
-                 An(i,j,k,2,TT,TT) = 0.0
+                 An(5,TT,TT,i,j,k) = An(5,TT,TT,i,j,k) + An(2,TT,TT,i,j,k)
+                 An(2,TT,TT,i,j,k) = 0.0
               endif
               if (east == LAND) then
-                 An(i,j,k,5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,8,TT,TT)
-                 An(i,j,k,8,TT,TT) = 0.0
+                 An(5,TT,TT,i,j,k) = An(5,TT,TT,i,j,k) + An(8,TT,TT,i,j,k)
+                 An(8,TT,TT,i,j,k) = 0.0
               endif
               if (north == LAND) then
-                 An(i,j,k,5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,6,TT,TT)
-                 An(i,j,k,6,TT,TT) = 0.0
+                 An(5,TT,TT,i,j,k) = An(5,TT,TT,i,j,k) + An(6,TT,TT,i,j,k)
+                 An(6,TT,TT,i,j,k) = 0.0
               endif
               if (south == LAND) then
-                 An(i,j,k,5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,4,TT,TT)
-                 An(i,j,k,4,TT,TT) = 0.0
+                 An(5,TT,TT,i,j,k) = An(5,TT,TT,i,j,k) + An(4,TT,TT,i,j,k)
+                 An(4,TT,TT,i,j,k) = 0.0
               endif
               !------- CENTER = not OCEAN or ATMOSPHERE -----------------------------
               ! so this is probably on LAND
            else
-              An(i,j,k,:,:,:) = 0.0
+              An(:,:,:,i,j,k) = 0.0
               do ii = 1, nun
                  Frc(find_row2(i,j,k,ii)) = 0.0
-                 An(i,j,k,5,ii,ii) = 1.0
+                 An(5,ii,ii,i,j,k) = 1.0
               enddo
            endif
         enddo
      enddo
   enddo
+
+  call TIMER_STOP('boundaries' // char(0))
 end subroutine boundaries

--- a/src/ocean/boundary.F90
+++ b/src/ocean/boundary.F90
@@ -81,54 +81,54 @@ subroutine boundaries
               ! on mirror/boundary points
               if (bottom == LAND) then  ! 14
                  if ((westb==LAND).and.(southwb==LAND).and.(southb==LAND)) then
-                    Al(i,j,k, 1,: ,UU) = Al(i,j,k,1,: ,UU) + Al(i,j,k,10,: ,UU) ! ACdN
-                    Al(i,j,k, 1,: ,VV) = Al(i,j,k,1,: ,VV) + Al(i,j,k,10,: ,VV) ! ACdN
+                    An(i,j,k, 1,: ,UU) = An(i,j,k,1,: ,UU) + An(i,j,k,10,: ,UU) ! ACdN
+                    An(i,j,k, 1,: ,VV) = An(i,j,k,1,: ,VV) + An(i,j,k,10,: ,VV) ! ACdN
                  endif
-                 Al(i,j,k,10,: ,UU) = 0.0
-                 Al(i,j,k,10,: ,VV) = 0.0
+                 An(i,j,k,10,: ,UU) = 0.0
+                 An(i,j,k,10,: ,VV) = 0.0
                  if ((westb==LAND).and.(neastb==LAND).and.(northb==LAND)) then
-                    Al(i,j,k, 2,: ,UU) = Al(i,j,k,2,: ,UU) + Al(i,j,k,11,: ,UU) ! ACdN
-                    Al(i,j,k, 2,: ,VV) = Al(i,j,k,2,: ,VV) + Al(i,j,k,11,: ,VV) ! ACdN
+                    An(i,j,k, 2,: ,UU) = An(i,j,k,2,: ,UU) + An(i,j,k,11,: ,UU) ! ACdN
+                    An(i,j,k, 2,: ,VV) = An(i,j,k,2,: ,VV) + An(i,j,k,11,: ,VV) ! ACdN
                  endif
-                 Al(i,j,k,11,: ,UU) = 0.0 !ACdN
-                 Al(i,j,k,11,: ,VV) = 0.0 !ACdN
+                 An(i,j,k,11,: ,UU) = 0.0 !ACdN
+                 An(i,j,k,11,: ,VV) = 0.0 !ACdN
                  if ((eastb==LAND).and.(southeb==LAND).and.(southb==LAND)) then
-                    Al(i,j,k, 4,: ,UU) = Al(i,j,k,4,: ,UU) + Al(i,j,k,13,: ,UU) ! ACdN
-                    Al(i,j,k, 4,: ,VV) = Al(i,j,k,4,: ,VV) + Al(i,j,k,13,: ,VV) ! ACdN
+                    An(i,j,k, 4,: ,UU) = An(i,j,k,4,: ,UU) + An(i,j,k,13,: ,UU) ! ACdN
+                    An(i,j,k, 4,: ,VV) = An(i,j,k,4,: ,VV) + An(i,j,k,13,: ,VV) ! ACdN
                  endif
-                 Al(i,j,k,13,: ,UU) = 0.0 !ACdN
-                 Al(i,j,k,13,: ,VV) = 0.0 !ACdN
+                 An(i,j,k,13,: ,UU) = 0.0 !ACdN
+                 An(i,j,k,13,: ,VV) = 0.0 !ACdN
                  if ((eastb==LAND).and.(neastb==LAND).and.(northb==LAND)) then
-                    Al(i,j,k, 5,: ,UU) = Al(i,j,k,5,: ,UU) + Al(i,j,k,14,: ,UU) ! ACdN
-                    Al(i,j,k, 5,: ,VV) = Al(i,j,k,5,: ,VV) + Al(i,j,k,14,: ,VV) ! ACdN
+                    An(i,j,k, 5,: ,UU) = An(i,j,k,5,: ,UU) + An(i,j,k,14,: ,UU) ! ACdN
+                    An(i,j,k, 5,: ,VV) = An(i,j,k,5,: ,VV) + An(i,j,k,14,: ,VV) ! ACdN
                  endif
-                 Al(i,j,k, 5,: ,TT) = Al(i,j,k,5,: ,TT) + Al(i,j,k,14,: ,TT) ! ACdN
-                 Al(i,j,k, 5,: ,SS) = Al(i,j,k,5,: ,SS) + Al(i,j,k,14,: ,SS) ! ACdN
-                 Al(i,j,k,14,: ,: ) = 0.0
+                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,14,: ,TT) ! ACdN
+                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,14,: ,SS) ! ACdN
+                 An(i,j,k,14,: ,: ) = 0.0
               endif
               if (southwb == LAND) then ! 10
-                 Al(i,j,k,10,: ,: ) = 0.0
+                 An(i,j,k,10,: ,: ) = 0.0
               endif
               if (westb == LAND) then   ! 11
-                 Al(i,j,k,11,: ,: ) = 0.0
+                 An(i,j,k,11,: ,: ) = 0.0
               endif
               if (nwestb == LAND) then  ! 12
-                 Al(i,j,k,12,: ,: ) = 0.0
+                 An(i,j,k,12,: ,: ) = 0.0
               endif
               if (southb == LAND) then  ! 13
-                 Al(i,j,k,13,: ,:)   = 0.0
+                 An(i,j,k,13,: ,:)   = 0.0
               endif
               if (northb == LAND) then  ! 15
-                 Al(i,j,k,15,: ,:)  = 0.0
+                 An(i,j,k,15,: ,:)  = 0.0
               endif
               if (southeb == LAND) then ! 16
-                 Al(i,j,k,16,: ,:)  = 0.0
+                 An(i,j,k,16,: ,:)  = 0.0
               endif
               if (eastb == LAND) then   ! 17
-                 Al(i,j,k,17,: ,:)  = 0.0
+                 An(i,j,k,17,: ,:)  = 0.0
               endif
               if (neastb == LAND) then  ! 18
-                 Al(i,j,k,18,: ,:)  = 0.0
+                 An(i,j,k,18,: ,:)  = 0.0
               endif
               if (top == LAND) then ! 23
                  ! cannot occur in real flow domain, LAND above OCEAN is illegal
@@ -137,229 +137,229 @@ subroutine boundaries
                     write(f99,*) i,j,k, landm(i  ,j  ,k),landm(i  ,j  ,k+1)
                  endif
                  if ((westt==LAND).and.(southwt==LAND).and.(southt==LAND)) then
-                    Al(i,j,k, 1,: ,UU) = Al(i,j,k,1,: ,UU) + Al(i,j,k,19,: ,UU) ! ACdN
-                    Al(i,j,k, 1,: ,VV) = Al(i,j,k,1,: ,VV) + Al(i,j,k,19,: ,VV) ! ACdN
+                    An(i,j,k, 1,: ,UU) = An(i,j,k,1,: ,UU) + An(i,j,k,19,: ,UU) ! ACdN
+                    An(i,j,k, 1,: ,VV) = An(i,j,k,1,: ,VV) + An(i,j,k,19,: ,VV) ! ACdN
                  endif
-                 Al(i,j,k,19,: ,UU) = 0.0
-                 Al(i,j,k,19,: ,VV) = 0.0
+                 An(i,j,k,19,: ,UU) = 0.0
+                 An(i,j,k,19,: ,VV) = 0.0
                  if ((westt==LAND).and.(nwestt==LAND).and.(northt==LAND)) then
-                    Al(i,j,k, 2,: ,UU) = Al(i,j,k,2,: ,UU) + Al(i,j,k,20,: ,UU) ! ACdN
-                    Al(i,j,k, 2,: ,VV) = Al(i,j,k,2,: ,VV) + Al(i,j,k,20,: ,VV) ! ACdN
+                    An(i,j,k, 2,: ,UU) = An(i,j,k,2,: ,UU) + An(i,j,k,20,: ,UU) ! ACdN
+                    An(i,j,k, 2,: ,VV) = An(i,j,k,2,: ,VV) + An(i,j,k,20,: ,VV) ! ACdN
                  endif
-                 Al(i,j,k,20,: ,UU) = 0.0 !ACdN
-                 Al(i,j,k,20,: ,VV) = 0.0 !ACdN
+                 An(i,j,k,20,: ,UU) = 0.0 !ACdN
+                 An(i,j,k,20,: ,VV) = 0.0 !ACdN
                  if ((eastt==LAND).and.(southet==LAND).and.(southt==LAND)) then
-                    Al(i,j,k, 4,: ,UU) = Al(i,j,k,4,: ,UU) + Al(i,j,k,22,: ,UU) ! ACdN
-                    Al(i,j,k, 4,: ,VV) = Al(i,j,k,4,: ,VV) + Al(i,j,k,22,: ,VV) ! ACdN
+                    An(i,j,k, 4,: ,UU) = An(i,j,k,4,: ,UU) + An(i,j,k,22,: ,UU) ! ACdN
+                    An(i,j,k, 4,: ,VV) = An(i,j,k,4,: ,VV) + An(i,j,k,22,: ,VV) ! ACdN
                  endif
-                 Al(i,j,k,22,: ,UU) = 0.0 !ACdN
-                 Al(i,j,k,22,: ,VV) = 0.0 !ACdN
+                 An(i,j,k,22,: ,UU) = 0.0 !ACdN
+                 An(i,j,k,22,: ,VV) = 0.0 !ACdN
                  if ((eastt==LAND).and.(neastt==LAND).and.(northt==LAND)) then
-                    Al(i,j,k, 5,: ,UU) = Al(i,j,k,5,: ,UU) + Al(i,j,k,23,: ,UU) ! ACdN
-                    Al(i,j,k, 5,: ,VV) = Al(i,j,k,5,: ,VV) + Al(i,j,k,23,: ,VV) ! ACdN
+                    An(i,j,k, 5,: ,UU) = An(i,j,k,5,: ,UU) + An(i,j,k,23,: ,UU) ! ACdN
+                    An(i,j,k, 5,: ,VV) = An(i,j,k,5,: ,VV) + An(i,j,k,23,: ,VV) ! ACdN
                  endif
-                 Al(i,j,k, 5,: ,TT) = Al(i,j,k,5,: ,TT) + Al(i,j,k,23,: ,TT) ! ACdN
-                 Al(i,j,k, 5,: ,SS) = Al(i,j,k,5,: ,SS) + Al(i,j,k,23,: ,SS) ! ACdN
-                 Al(i,j,k,23,: ,: ) = 0.0
+                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,23,: ,TT) ! ACdN
+                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,23,: ,SS) ! ACdN
+                 An(i,j,k,23,: ,: ) = 0.0
 
                  Frc(find_row2(i,j,k,WW)) = 0.0
-                 Al(i,j,k, :,WW,: ) = 0.0
+                 An(i,j,k, :,WW,: ) = 0.0
                  ! FIXME preconditioner breakdown if we remove the
                  ! connections, hence we try to maintain the
                  ! connection but make it inactive with 1e-10
-                 Al(i,j,k, 5, :,WW) = 1.0e-10 !MdT !TEM
-                 Al(i,j,k, 6, :,WW) = 1.0e-10 !MdT !TEM
-                 Al(i,j,k, 8, :,WW) = 1.0e-10 !MdT !TEM
-                 Al(i,j,k, 9, :,WW) = 1.0e-10 !MdT !TEM
-                 Al(i,j,k, 5,WW,WW) = 1.0
+                 An(i,j,k, 5, :,WW) = 1.0e-10 !MdT !TEM
+                 An(i,j,k, 6, :,WW) = 1.0e-10 !MdT !TEM
+                 An(i,j,k, 8, :,WW) = 1.0e-10 !MdT !TEM
+                 An(i,j,k, 9, :,WW) = 1.0e-10 !MdT !TEM
+                 An(i,j,k, 5,WW,WW) = 1.0
 
               endif
               if (top == ATMOS) then ! deprecated in i-emic
-                 Al(i,j,k, 1,: ,UU) = Al(i,j,k,1,: ,UU) + Al(i,j,k,19,: ,UU) ! ACdN
-                 Al(i,j,k, 1,: ,VV) = Al(i,j,k,1,: ,VV) + Al(i,j,k,19,: ,VV) ! ACdN
-                 Al(i,j,k,19,: ,UU) = 0.0
-                 Al(i,j,k,19,: ,VV) = 0.0
-                 Al(i,j,k, 2,: ,UU) = Al(i,j,k,2,: ,UU) + Al(i,j,k,20,: ,UU) ! ACdN
-                 Al(i,j,k, 2,: ,VV) = Al(i,j,k,2,: ,VV) + Al(i,j,k,20,: ,VV) ! ACdN
-                 Al(i,j,k,20,: ,UU) = 0.0 !ACdN
-                 Al(i,j,k,20,: ,VV) = 0.0 !ACdN
-                 Al(i,j,k, 4,: ,UU) = Al(i,j,k,4,: ,UU) + Al(i,j,k,22,: ,UU) ! ACdN
-                 Al(i,j,k, 4,: ,VV) = Al(i,j,k,4,: ,VV) + Al(i,j,k,22,: ,VV) ! ACdN
-                 Al(i,j,k,22,: ,UU) = 0.0 !ACdN
-                 Al(i,j,k,22,: ,VV) = 0.0 !ACdN
-                 Al(i,j,k, 5,: ,UU) = Al(i,j,k,5,: ,UU) + Al(i,j,k,23,: ,UU) ! ACdN
-                 Al(i,j,k, 5,: ,VV) = Al(i,j,k,5,: ,VV) + Al(i,j,k,23,: ,VV) ! ACdN
-                 Al(i,j,k, 5,SS,SS) = Al(i,j,k,5,SS,SS) + Al(i,j,k,23,SS,SS)
-                 Al(i,j,k,23,SS,SS) = 0.0
+                 An(i,j,k, 1,: ,UU) = An(i,j,k,1,: ,UU) + An(i,j,k,19,: ,UU) ! ACdN
+                 An(i,j,k, 1,: ,VV) = An(i,j,k,1,: ,VV) + An(i,j,k,19,: ,VV) ! ACdN
+                 An(i,j,k,19,: ,UU) = 0.0
+                 An(i,j,k,19,: ,VV) = 0.0
+                 An(i,j,k, 2,: ,UU) = An(i,j,k,2,: ,UU) + An(i,j,k,20,: ,UU) ! ACdN
+                 An(i,j,k, 2,: ,VV) = An(i,j,k,2,: ,VV) + An(i,j,k,20,: ,VV) ! ACdN
+                 An(i,j,k,20,: ,UU) = 0.0 !ACdN
+                 An(i,j,k,20,: ,VV) = 0.0 !ACdN
+                 An(i,j,k, 4,: ,UU) = An(i,j,k,4,: ,UU) + An(i,j,k,22,: ,UU) ! ACdN
+                 An(i,j,k, 4,: ,VV) = An(i,j,k,4,: ,VV) + An(i,j,k,22,: ,VV) ! ACdN
+                 An(i,j,k,22,: ,UU) = 0.0 !ACdN
+                 An(i,j,k,22,: ,VV) = 0.0 !ACdN
+                 An(i,j,k, 5,: ,UU) = An(i,j,k,5,: ,UU) + An(i,j,k,23,: ,UU) ! ACdN
+                 An(i,j,k, 5,: ,VV) = An(i,j,k,5,: ,VV) + An(i,j,k,23,: ,VV) ! ACdN
+                 An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,23,SS,SS)
+                 An(i,j,k,23,SS,SS) = 0.0
 
                  Frc(find_row2(i,j,k,WW)) = 0.0
-                 Al(i,j,k, :,WW,: ) = 0.0
+                 An(i,j,k, :,WW,: ) = 0.0
                  ! preconditioner breakdown if we do this:
-                 ! Al(i,j,k, 5, :,WW) = 0.0 ! 1.0e-10 !MdT
-                 ! Al(i,j,k, 6, :,WW) = 0.0 ! 1.0e-10 !MdT
-                 ! Al(i,j,k, 8, :,WW) = 0.0 ! 1.0e-10 !MdT
-                 ! Al(i,j,k, 9, :,WW) = 0.0 ! 1.0e-10 !MdT
-                 Al(i,j,k, 5,WW,WW) = 1.0
+                 ! An(i,j,k, 5, :,WW) = 0.0 ! 1.0e-10 !MdT
+                 ! An(i,j,k, 6, :,WW) = 0.0 ! 1.0e-10 !MdT
+                 ! An(i,j,k, 8, :,WW) = 0.0 ! 1.0e-10 !MdT
+                 ! An(i,j,k, 9, :,WW) = 0.0 ! 1.0e-10 !MdT
+                 An(i,j,k, 5,WW,WW) = 1.0
 
               endif
               !     if (southwt == LAND) then   ! 19
               if ((southwt == LAND).OR.(southwt ==ATMOS)) then  ! 19
-                 Al(i,j,k,19,: ,:)  = 0.0
+                 An(i,j,k,19,: ,:)  = 0.0
               endif
               !     if (westt == LAND) then     ! 20
               if ((westt == LAND).OR.(westt == ATMOS)) then     ! 20
-                 Al(i,j,k,20,: ,: ) = 0.0
+                 An(i,j,k,20,: ,: ) = 0.0
               endif
               if ((nwestt == LAND).OR.(nwestt == ATMOS)) then   ! 21
-                 Al(i,j,k,21,:,:)    = 0.0
+                 An(i,j,k,21,:,:)    = 0.0
               endif
               if ((southt == LAND).OR.(southt == ATMOS)) then   ! 22
-                 Al(i,j,k,22,: ,:)   = 0.0
+                 An(i,j,k,22,: ,:)   = 0.0
               endif
               if ((northt == LAND).OR.(northt == ATMOS)) then   ! 24
-                 Al(i,j,k,24,: ,:)  = 0.0
+                 An(i,j,k,24,: ,:)  = 0.0
               endif
               if ((southet == LAND).OR.(southet == ATMOS)) then ! 25
-                 Al(i,j,k,25,: ,:)  = 0.0
+                 An(i,j,k,25,: ,:)  = 0.0
               endif
               if ((eastt == LAND).OR.(eastt == ATMOS)) then     ! 26
-                 Al(i,j,k,26,: ,:)  = 0.0
+                 An(i,j,k,26,: ,:)  = 0.0
               endif
               if ((neastt == LAND).OR.(neastt == ATMOS)) then   ! 27
-                 Al(i,j,k,27,: ,:)  = 0.0
+                 An(i,j,k,27,: ,:)  = 0.0
               endif
               if (southw == LAND) then  ! 1
-                 Al(i,j,k, 1,: ,UU) = 0.0
-                 Al(i,j,k, 1,: ,VV) = 0.0
+                 An(i,j,k, 1,: ,UU) = 0.0
+                 An(i,j,k, 1,: ,VV) = 0.0
               endif
               if (west == LAND) then    ! 2
-                 Al(i,j,k, 5,: ,TT) = Al(i,j,k,5,: ,TT) + Al(i,j,k,2,: ,TT) ! ACdN
-                 Al(i,j,k, 5,: ,SS) = Al(i,j,k,5,: ,SS) + Al(i,j,k,2,: ,SS) ! ACdN
-                 !              Al(i,j,k, 5,TT,TT) = Al(i,j,k,5,TT,TT) + Al(i,j,k,2,TT,TT)
-                 !              Al(i,j,k, 5,SS,SS) = Al(i,j,k,5,SS,SS) + Al(i,j,k,2,SS,SS)
-                 !              Al(i,j,k, 5,TT,SS) = Al(i,j,k,5,TT,SS) + Al(i,j,k,2,TT,SS)
-                 !              Al(i,j,k, 5,SS,TT) = Al(i,j,k,5,SS,TT) + Al(i,j,k,2,SS,TT)
-                 Al(i,j,k, 2,: ,: ) = 0.0
-                 Al(i,j,k, 1,: ,UU) = 0.0
-                 Al(i,j,k, 1,: ,VV) = 0.0
+                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,2,: ,TT) ! ACdN
+                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,2,: ,SS) ! ACdN
+                 !              An(i,j,k, 5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,2,TT,TT)
+                 !              An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,2,SS,SS)
+                 !              An(i,j,k, 5,TT,SS) = An(i,j,k,5,TT,SS) + An(i,j,k,2,TT,SS)
+                 !              An(i,j,k, 5,SS,TT) = An(i,j,k,5,SS,TT) + An(i,j,k,2,SS,TT)
+                 An(i,j,k, 2,: ,: ) = 0.0
+                 An(i,j,k, 1,: ,UU) = 0.0
+                 An(i,j,k, 1,: ,VV) = 0.0
               endif
               if (nwest == LAND) then   ! 3
-                 Al(i,j,k, 2,: ,UU) = 0.0
-                 Al(i,j,k, 2,: ,VV) = 0.0
-                 Al(i,j,k, 3,: ,UU) = 0.0
-                 Al(i,j,k, 3,: ,VV) = 0.0
+                 An(i,j,k, 2,: ,UU) = 0.0
+                 An(i,j,k, 2,: ,VV) = 0.0
+                 An(i,j,k, 3,: ,UU) = 0.0
+                 An(i,j,k, 3,: ,VV) = 0.0
               elseif (j.lt.m) then
                  if (nnwest == LAND) then
-                    Al(i,j,k, 3,: ,UU) = 0.0
-                    Al(i,j,k, 3,: ,VV) = 0.0
+                    An(i,j,k, 3,: ,UU) = 0.0
+                    An(i,j,k, 3,: ,VV) = 0.0
                  endif
               endif
               if (south == LAND) then   ! 4
-                 Al(i,j,k, 5,: ,SS) = Al(i,j,k,5,: ,SS) + Al(i,j,k,4,: ,SS) ! ACdN
-                 Al(i,j,k, 5,: ,TT) = Al(i,j,k,5,: ,TT) + Al(i,j,k,4,: ,TT) ! ACdN
-                 !   Al(i,j,k, 5,TT,TT) = Al(i,j,k,5,TT,TT) + Al(i,j,k,4,TT,TT)
-                 !   Al(i,j,k, 5,SS,SS) = Al(i,j,k,5,SS,SS) + Al(i,j,k,4,SS,SS)
-                 !   Al(i,j,k, 5,TT,SS) = Al(i,j,k,5,TT,SS) + Al(i,j,k,4,TT,SS)
-                 !   Al(i,j,k, 5,SS,TT) = Al(i,j,k,5,SS,TT) + Al(i,j,k,4,SS,TT)
-                 Al(i,j,k, 4,: ,: ) = 0.0
-                 Al(i,j,k, 1,: ,UU) = 0.0
-                 Al(i,j,k, 1,: ,VV) = 0.0
+                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,4,: ,SS) ! ACdN
+                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,4,: ,TT) ! ACdN
+                 !   An(i,j,k, 5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,4,TT,TT)
+                 !   An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,4,SS,SS)
+                 !   An(i,j,k, 5,TT,SS) = An(i,j,k,5,TT,SS) + An(i,j,k,4,TT,SS)
+                 !   An(i,j,k, 5,SS,TT) = An(i,j,k,5,SS,TT) + An(i,j,k,4,SS,TT)
+                 An(i,j,k, 4,: ,: ) = 0.0
+                 An(i,j,k, 1,: ,UU) = 0.0
+                 An(i,j,k, 1,: ,VV) = 0.0
               endif
               if (north == LAND) then   ! 6
-                 Al(i,j,k, 2,: ,UU) = 0.0
-                 Al(i,j,k, 2,: ,VV) = 0.0
+                 An(i,j,k, 2,: ,UU) = 0.0
+                 An(i,j,k, 2,: ,VV) = 0.0
                  !
                  ! continuity
                  !
-                 Al(i,j,k, 2,PP,UU) = 0.0
-                 Al(i,j,k, 2,PP,VV) = 0.0
-                 Al(i,j,k, 5,PP,UU) = 0.0
-                 Al(i,j,k, 5,PP,VV) = 0.0
+                 An(i,j,k, 2,PP,UU) = 0.0
+                 An(i,j,k, 2,PP,VV) = 0.0
+                 An(i,j,k, 5,PP,UU) = 0.0
+                 An(i,j,k, 5,PP,VV) = 0.0
                  !
                  ! theta momentum
                  !
                  Frc(find_row2(i,j,k,VV)) = 0.0
-                 Al(i,j,k, :,VV,: ) = 0.0
-                 Al(i,j,k, 5,: ,VV) = 0.0 ! ACdN
-                 Al(i,j,k, 5,VV,VV) = 1.0
+                 An(i,j,k, :,VV,: ) = 0.0
+                 An(i,j,k, 5,: ,VV) = 0.0 ! ACdN
+                 An(i,j,k, 5,VV,VV) = 1.0
                  !
                  ! phi momentum
                  !
                  Frc(find_row2(i,j,k,UU)) = 0.0
-                 Al(i,j,k, :,UU, :) = 0.0
-                 Al(i,j,k, 5,: ,UU) = 0.0 ! ACdN
-                 Al(i,j,k, 5,UU,UU) = 1.0
+                 An(i,j,k, :,UU, :) = 0.0
+                 An(i,j,k, 5,: ,UU) = 0.0 ! ACdN
+                 An(i,j,k, 5,UU,UU) = 1.0
                  !
                  ! tracers
                  !
-                 Al(i,j,k, 5,: ,SS) = Al(i,j,k,5,: ,SS) + Al(i,j,k,6,: ,SS) ! ACdN
-                 Al(i,j,k, 5,: ,TT) = Al(i,j,k,5,: ,TT) + Al(i,j,k,6,: ,TT) ! ACdN
-                 !   Al(i,j,k, 5,TT,TT) = Al(i,j,k,5,TT,TT) + Al(i,j,k,6,TT,TT)
-                 !   Al(i,j,k, 5,SS,SS) = Al(i,j,k,5,SS,SS) + Al(i,j,k,6,SS,SS)
-                 !   Al(i,j,k, 5,TT,SS) = Al(i,j,k,5,TT,SS) + Al(i,j,k,6,TT,SS)
-                 !   Al(i,j,k, 5,SS,TT) = Al(i,j,k,5,SS,TT) + Al(i,j,k,6,SS,TT)
-                 Al(i,j,k, 6,: ,: ) = 0.0
+                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,6,: ,SS) ! ACdN
+                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,6,: ,TT) ! ACdN
+                 !   An(i,j,k, 5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,6,TT,TT)
+                 !   An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,6,SS,SS)
+                 !   An(i,j,k, 5,TT,SS) = An(i,j,k,5,TT,SS) + An(i,j,k,6,TT,SS)
+                 !   An(i,j,k, 5,SS,TT) = An(i,j,k,5,SS,TT) + An(i,j,k,6,SS,TT)
+                 An(i,j,k, 6,: ,: ) = 0.0
               elseif (j.lt.m) then
                  if (nnorth == LAND) then
-                    Al(i,j,k, 3,: ,UU) = 0.0
-                    Al(i,j,k, 3,: ,VV) = 0.0
-                    Al(i,j,k, 6,: ,UU) = 0.0
-                    Al(i,j,k, 6,: ,VV) = 0.0
+                    An(i,j,k, 3,: ,UU) = 0.0
+                    An(i,j,k, 3,: ,VV) = 0.0
+                    An(i,j,k, 6,: ,UU) = 0.0
+                    An(i,j,k, 6,: ,VV) = 0.0
                  endif
               endif
               if (southe == LAND) then  ! 7
-                 Al(i,j,k, 4, :,UU) = 0.0
-                 Al(i,j,k, 4, :,VV) = 0.0
-                 Al(i,j,k, 7, :,UU) = 0.0
-                 Al(i,j,k, 7, :,VV) = 0.0
+                 An(i,j,k, 4, :,UU) = 0.0
+                 An(i,j,k, 4, :,VV) = 0.0
+                 An(i,j,k, 7, :,UU) = 0.0
+                 An(i,j,k, 7, :,VV) = 0.0
               elseif (i.lt.n) then
                  if (southee == LAND) then
-                    Al(i,j,k, 7,: ,UU) = 0.0
-                    Al(i,j,k, 7,: ,VV) = 0.0
+                    An(i,j,k, 7,: ,UU) = 0.0
+                    An(i,j,k, 7,: ,VV) = 0.0
                  endif
               endif
               if (east == LAND) then    ! 8
-                 Al(i,j,k, 4,: ,UU) = 0.0
-                 Al(i,j,k, 4,: ,VV) = 0.0
+                 An(i,j,k, 4,: ,UU) = 0.0
+                 An(i,j,k, 4,: ,VV) = 0.0
                  !
                  ! continuity
                  !
-                 Al(i,j,k, 4,PP,UU) = 0.0
-                 Al(i,j,k, 4,PP,VV) = 0.0
-                 Al(i,j,k, 5,PP,UU) = 0.0
-                 Al(i,j,k, 5,PP,VV) = 0.0
+                 An(i,j,k, 4,PP,UU) = 0.0
+                 An(i,j,k, 4,PP,VV) = 0.0
+                 An(i,j,k, 5,PP,UU) = 0.0
+                 An(i,j,k, 5,PP,VV) = 0.0
                  !
                  ! phi momentum
                  !
                  Frc(find_row2(i,j,k,UU)) = 0.0
-                 Al(i,j,k, :,UU,: ) = 0.0
-                 Al(i,j,k, 5,: ,UU) = 0.0 ! ACdN
-                 Al(i,j,k, 5,UU,UU) = 1.0
+                 An(i,j,k, :,UU,: ) = 0.0
+                 An(i,j,k, 5,: ,UU) = 0.0 ! ACdN
+                 An(i,j,k, 5,UU,UU) = 1.0
                  !
                  ! theta momentum
                  !
                  Frc(find_row2(i,j,k,VV)) = 0.0
-                 Al(i,j,k, :,VV, :) = 0.0
-                 Al(i,j,k, 5,: ,VV) = 0.0 ! ACdN
-                 Al(i,j,k, 5,VV,VV) = 1.0
+                 An(i,j,k, :,VV, :) = 0.0
+                 An(i,j,k, 5,: ,VV) = 0.0 ! ACdN
+                 An(i,j,k, 5,VV,VV) = 1.0
                  !
                  ! tracers
                  !
-                 Al(i,j,k, 5,: ,SS) = Al(i,j,k,5,: ,SS) + Al(i,j,k,8,: ,SS)
-                 Al(i,j,k, 5,: ,TT) = Al(i,j,k,5,: ,TT) + Al(i,j,k,8,: ,TT)
-                 !   Al(i,j,k, 5,TT,TT) = Al(i,j,k,5,TT,TT) + Al(i,j,k,8,TT,TT)
-                 !   Al(i,j,k, 5,SS,SS) = Al(i,j,k,5,SS,SS) + Al(i,j,k,8,SS,SS)
-                 !   Al(i,j,k, 5,TT,SS) = Al(i,j,k,5,TT,SS) + Al(i,j,k,8,TT,SS)
-                 !   Al(i,j,k, 5,SS,TT) = Al(i,j,k,5,SS,TT) + Al(i,j,k,8,SS,TT)
-                 Al(i,j,k, 8,: ,: ) = 0.0
-                 Al(i,j,k, 7, :,UU) = 0.0
-                 Al(i,j,k, 7, :,VV) = 0.0
+                 An(i,j,k, 5,: ,SS) = An(i,j,k,5,: ,SS) + An(i,j,k,8,: ,SS)
+                 An(i,j,k, 5,: ,TT) = An(i,j,k,5,: ,TT) + An(i,j,k,8,: ,TT)
+                 !   An(i,j,k, 5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,8,TT,TT)
+                 !   An(i,j,k, 5,SS,SS) = An(i,j,k,5,SS,SS) + An(i,j,k,8,SS,SS)
+                 !   An(i,j,k, 5,TT,SS) = An(i,j,k,5,TT,SS) + An(i,j,k,8,TT,SS)
+                 !   An(i,j,k, 5,SS,TT) = An(i,j,k,5,SS,TT) + An(i,j,k,8,SS,TT)
+                 An(i,j,k, 8,: ,: ) = 0.0
+                 An(i,j,k, 7, :,UU) = 0.0
+                 An(i,j,k, 7, :,VV) = 0.0
               elseif (i.lt.n) then
                  if (easteast == LAND) then
-                    Al(i,j,k, 7,: ,UU) = 0.0
-                    Al(i,j,k, 7,: ,VV) = 0.0
-                    Al(i,j,k, 8,: ,UU) = 0.0
-                    Al(i,j,k, 8,: ,VV) = 0.0
+                    An(i,j,k, 7,: ,UU) = 0.0
+                    An(i,j,k, 7,: ,VV) = 0.0
+                    An(i,j,k, 8,: ,UU) = 0.0
+                    An(i,j,k, 8,: ,VV) = 0.0
                  endif
               endif
               if (neast == LAND) then   ! 9
@@ -367,38 +367,38 @@ subroutine boundaries
                  ! phi momentum
                  !
                  Frc(find_row2(i,j,k,UU)) = 0.0
-                 Al(i,j,k, :,UU,: ) = 0.0
-                 Al(i,j,k, 5,: ,UU) = 0.0
-                 Al(i,j,k, 5,UU,UU) = 1.0
+                 An(i,j,k, :,UU,: ) = 0.0
+                 An(i,j,k, 5,: ,UU) = 0.0
+                 An(i,j,k, 5,UU,UU) = 1.0
                  !
                  ! theta momentum
                  !
                  Frc(find_row2(i,j,k,VV)) = 0.0
-                 Al(i,j,k, :,VV,: ) = 0.0
-                 Al(i,j,k, 5,: ,VV) = 0.0
-                 Al(i,j,k, 5,VV,VV) = 1.0
-                 Al(i,j,k, 7, :,UU) = 0.0
-                 Al(i,j,k, 7, :,VV) = 0.0
+                 An(i,j,k, :,VV,: ) = 0.0
+                 An(i,j,k, 5,: ,VV) = 0.0
+                 An(i,j,k, 5,VV,VV) = 1.0
+                 An(i,j,k, 7, :,UU) = 0.0
+                 An(i,j,k, 7, :,VV) = 0.0
               elseif ((i.lt.n).or.(j.lt.m)) then
                  if (i.lt.n) then
                     if (northee == LAND) then
-                       Al(i,j,k, 8,: ,UU) = 0.0
-                       Al(i,j,k, 8,: ,VV) = 0.0
-                       Al(i,j,k, 9,: ,UU) = 0.0
-                       Al(i,j,k, 9,: ,VV) = 0.0
+                       An(i,j,k, 8,: ,UU) = 0.0
+                       An(i,j,k, 8,: ,VV) = 0.0
+                       An(i,j,k, 9,: ,UU) = 0.0
+                       An(i,j,k, 9,: ,VV) = 0.0
                     elseif (j.lt.m) then
                        if (nnorthee == LAND) then
-                          Al(i,j,k, 9,: ,UU) = 0.0
-                          Al(i,j,k, 9,: ,VV) = 0.0
+                          An(i,j,k, 9,: ,UU) = 0.0
+                          An(i,j,k, 9,: ,VV) = 0.0
                        endif
                     endif
                  endif
                  if (j.lt.m) then
                     if (nneast == LAND) then
-                       Al(i,j,k, 6,: ,UU) = 0.0
-                       Al(i,j,k, 6,: ,VV) = 0.0
-                       Al(i,j,k, 9,: ,UU) = 0.0
-                       Al(i,j,k, 9,: ,VV) = 0.0
+                       An(i,j,k, 6,: ,UU) = 0.0
+                       An(i,j,k, 6,: ,VV) = 0.0
+                       An(i,j,k, 9,: ,UU) = 0.0
+                       An(i,j,k, 9,: ,VV) = 0.0
                     endif
                  endif
               endif
@@ -406,28 +406,28 @@ subroutine boundaries
            else if (center == ATMOS) then
               write(*,*) 'center is atmos'
               if (west == LAND) then
-                 Al(i,j,k,5,TT,TT) = Al(i,j,k,5,TT,TT) + Al(i,j,k,2,TT,TT)
-                 Al(i,j,k,2,TT,TT) = 0.0
+                 An(i,j,k,5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,2,TT,TT)
+                 An(i,j,k,2,TT,TT) = 0.0
               endif
               if (east == LAND) then
-                 Al(i,j,k,5,TT,TT) = Al(i,j,k,5,TT,TT) + Al(i,j,k,8,TT,TT)
-                 Al(i,j,k,8,TT,TT) = 0.0
+                 An(i,j,k,5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,8,TT,TT)
+                 An(i,j,k,8,TT,TT) = 0.0
               endif
               if (north == LAND) then
-                 Al(i,j,k,5,TT,TT) = Al(i,j,k,5,TT,TT) + Al(i,j,k,6,TT,TT)
-                 Al(i,j,k,6,TT,TT) = 0.0
+                 An(i,j,k,5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,6,TT,TT)
+                 An(i,j,k,6,TT,TT) = 0.0
               endif
               if (south == LAND) then
-                 Al(i,j,k,5,TT,TT) = Al(i,j,k,5,TT,TT) + Al(i,j,k,4,TT,TT)
-                 Al(i,j,k,4,TT,TT) = 0.0
+                 An(i,j,k,5,TT,TT) = An(i,j,k,5,TT,TT) + An(i,j,k,4,TT,TT)
+                 An(i,j,k,4,TT,TT) = 0.0
               endif
               !------- CENTER = not OCEAN or ATMOSPHERE -----------------------------
               ! so this is probably on LAND
            else
-              Al(i,j,k,:,:,:) = 0.0
+              An(i,j,k,:,:,:) = 0.0
               do ii = 1, nun
                  Frc(find_row2(i,j,k,ii)) = 0.0
-                 Al(i,j,k,5,ii,ii) = 1.0
+                 An(i,j,k,5,ii,ii) = 1.0
               enddo
            endif
         enddo

--- a/src/ocean/mat.F90
+++ b/src/ocean/mat.F90
@@ -9,6 +9,7 @@ MODULE m_mat
 
   ! originally in usr.com:
   real,    dimension(:,:,:,:,:,:), ALLOCATABLE :: Al, An
+  real,    dimension(:,:,:), ALLOCATABLE :: Alocal
 
   ! originally in mat.com: now allocated in C++ via the
   ! subroutines get_array_sizes and set_pointers
@@ -18,23 +19,20 @@ MODULE m_mat
 
   integer :: maxnnz !! allocated memory for jacobian matrix entries
 
-  real(c_double), dimension(:), POINTER :: coB        
-
-  logical, dimension(:,:,:), ALLOCATABLE :: active
-  ! used to keep track on active couplings
+  real(c_double), dimension(:), POINTER :: coB
 
 contains
 
-  !! allocates the Al array and 'active'. The
+  !! allocates the Al and An arrays. The
   !! CRS matrix A and B are allocated by C++ via 'allocate_crs' (below)
   subroutine allocate_mat
 
     use m_usr
     implicit none
 
-    allocate(Al(n,m,l+la,np,nun,nun))
-    allocate(An(n,m,l+la,np,nun,nun))
-    allocate(active(np,nun,nun))
+    allocate(Al(np,nun,nun,n,m,l+la))
+    allocate(An(np,nun,nun,n,m,l+la))
+    allocate(Alocal(np,nun,nun))
 
   end subroutine allocate_mat
 
@@ -45,7 +43,7 @@ contains
 
     deallocate(Al)
     deallocate(An)
-    deallocate(active)
+    deallocate(Alocal)
 
   end subroutine deallocate_mat
 

--- a/src/ocean/mat.F90
+++ b/src/ocean/mat.F90
@@ -20,12 +20,9 @@ MODULE m_mat
 
   real(c_double), dimension(:), POINTER :: coB
 
-  logical, dimension(:,:,:), ALLOCATABLE :: active
-  ! used to keep track on active couplings
-
 contains
 
-  !! allocates the Al and An arrays and 'active'. The
+  !! allocates the Al and An arrays. The
   !! CRS matrix A and B are allocated by C++ via 'allocate_crs' (below)
   subroutine allocate_mat
 
@@ -34,7 +31,6 @@ contains
 
     allocate(Al(n,m,l+la,np,nun,nun))
     allocate(An(n,m,l+la,np,nun,nun))
-    allocate(active(np,nun,nun))
 
   end subroutine allocate_mat
 
@@ -45,7 +41,6 @@ contains
 
     deallocate(Al)
     deallocate(An)
-    deallocate(active)
 
   end subroutine deallocate_mat
 

--- a/src/ocean/mat.F90
+++ b/src/ocean/mat.F90
@@ -18,11 +18,14 @@ MODULE m_mat
 
   integer :: maxnnz !! allocated memory for jacobian matrix entries
 
-  real(c_double), dimension(:), POINTER :: coB
+  real(c_double), dimension(:), POINTER :: coB        
+
+  logical, dimension(:,:,:), ALLOCATABLE :: active
+  ! used to keep track on active couplings
 
 contains
 
-  !! allocates the Al and An arrays. The
+  !! allocates the Al array and 'active'. The
   !! CRS matrix A and B are allocated by C++ via 'allocate_crs' (below)
   subroutine allocate_mat
 
@@ -31,6 +34,7 @@ contains
 
     allocate(Al(n,m,l+la,np,nun,nun))
     allocate(An(n,m,l+la,np,nun,nun))
+    allocate(active(np,nun,nun))
 
   end subroutine allocate_mat
 
@@ -41,6 +45,7 @@ contains
 
     deallocate(Al)
     deallocate(An)
+    deallocate(active)
 
   end subroutine deallocate_mat
 

--- a/src/ocean/mat.F90
+++ b/src/ocean/mat.F90
@@ -5,27 +5,27 @@ MODULE m_mat
   use, intrinsic :: iso_c_binding
 
   ! defines the location of the matrix
-  ! replaces old common block file "mat.com" 
+  ! replaces old common block file "mat.com"
 
   ! originally in usr.com:
-  real,    dimension(:,:,:,:,:,:), ALLOCATABLE :: Al
+  real,    dimension(:,:,:,:,:,:), ALLOCATABLE :: Al, An
 
   ! originally in mat.com: now allocated in C++ via the
   ! subroutines get_array_sizes and set_pointers
   real(c_double), dimension(:), POINTER :: coA
-  integer(c_int), dimension(:), POINTER :: jcoA 
+  integer(c_int), dimension(:), POINTER :: jcoA
   integer(c_int), dimension(:), POINTER :: begA
 
   integer :: maxnnz !! allocated memory for jacobian matrix entries
 
-  real(c_double), dimension(:), POINTER :: coB        
+  real(c_double), dimension(:), POINTER :: coB
 
   logical, dimension(:,:,:), ALLOCATABLE :: active
   ! used to keep track on active couplings
 
 contains
 
-  !! allocates the Al array and 'active'. The
+  !! allocates the Al and An arrays and 'active'. The
   !! CRS matrix A and B are allocated by C++ via 'allocate_crs' (below)
   subroutine allocate_mat
 
@@ -33,6 +33,7 @@ contains
     implicit none
 
     allocate(Al(n,m,l+la,np,nun,nun))
+    allocate(An(n,m,l+la,np,nun,nun))
     allocate(active(np,nun,nun))
 
   end subroutine allocate_mat
@@ -43,6 +44,7 @@ contains
     implicit none
 
     deallocate(Al)
+    deallocate(An)
     deallocate(active)
 
   end subroutine deallocate_mat

--- a/src/ocean/mix_imp.f
+++ b/src/ocean/mix_imp.f
@@ -808,7 +808,7 @@ Call structure DSM and FDJS
             if (jy-iy.eq. -1) s  = s + 1
             if (jy-iy.eq.  0) s  = s + 2
             if (jy-iy.eq.  1) s  = s + 3
-            an(ix,iy,iz,s,ie,je) = an(ix,iy,iz,s,ie,je) + fjac(j)
+            an(s,ie,je,ix,iy,iz) = an(s,ie,je,ix,iy,iz) + fjac(j)
          enddo
       enddo
 

--- a/src/ocean/mix_imp.f
+++ b/src/ocean/mix_imp.f
@@ -808,7 +808,7 @@ Call structure DSM and FDJS
             if (jy-iy.eq. -1) s  = s + 1
             if (jy-iy.eq.  0) s  = s + 2
             if (jy-iy.eq.  1) s  = s + 3
-            al(ix,iy,iz,s,ie,je) = al(ix,iy,iz,s,ie,je) + fjac(j)
+            an(ix,iy,iz,s,ie,je) = an(ix,iy,iz,s,ie,je) + fjac(j)
          enddo
       enddo
 

--- a/src/ocean/spf.F90
+++ b/src/ocean/spf.F90
@@ -8,7 +8,7 @@
 !  |  below   || center||  above   |
 !  +----------++-------++----------+
 
-!    atom(i,j,k,loc)
+!    atom(loc,i,j,k)
 
 SUBROUTINE uderiv(type,atom)
   use m_usr
@@ -19,7 +19,7 @@ SUBROUTINE uderiv(type,atom)
   !     4:  uzz
   !     IMPORT/EXPORT
   integer type,i,j,k
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   real    cosdx2i(0:m),rdy2i,rdz2i,tand2(0:m),cosd2(0:m)
   real    h1,h2
   real    amh,bmh,bmhy
@@ -30,20 +30,20 @@ SUBROUTINE uderiv(type,atom)
      IF (itopo.eq.3) then
         DO i = 18,20
            DO j=1,3
-              atom(i,j,:,5) = 1.0
+              atom(5,i,j,:) = 1.0
            enddo
         enddo
      ELSE
-        atom(:,:,:,5) = 1.0
+        atom(5,:,:,:) = 1.0
      ENDIF
   CASE(2)
      ! u_xx
      cosdx2i = (1.0/(cos(yv)*dx))**2
      do j = 1, m - 1
         do i= 1, n
-           atom(i,j,:,2) =   amh(yv(j),ih)*cosdx2i(j)
-           atom(i,j,:,8) =   amh(yv(j),ih)*cosdx2i(j)
-           atom(i,j,:,5) = -(atom(i,j,:,2) + atom(i,j,:,8))
+           atom(2,i,j,:) =   amh(yv(j),ih)*cosdx2i(j)
+           atom(8,i,j,:) =   amh(yv(j),ih)*cosdx2i(j)
+           atom(5,i,j,:) = -(atom(2,i,j,:) + atom(8,i,j,:))
         enddo
      enddo
   CASE(3)
@@ -51,9 +51,9 @@ SUBROUTINE uderiv(type,atom)
      rdy2i = (1.0/dy)**2
      do i=1,n
         do j=1,m-1
-           atom(i,j,:,4) = rdy2i * bmh(y(j),ih)*cos(y(j))/cos(yv(j))
-           atom(i,j,:,6) = rdy2i * bmh(y(j+1),ih)*cos(y(j+1))/cos(yv(j))
-           atom(i,j,:,5) = -(atom(i,j,:,4) + atom(i,j,:,6))
+           atom(4,i,j,:) = rdy2i * bmh(y(j),ih)*cos(y(j))/cos(yv(j))
+           atom(6,i,j,:) = rdy2i * bmh(y(j+1),ih)*cos(y(j+1))/cos(yv(j))
+           atom(5,i,j,:) = -(atom(4,i,j,:) + atom(6,i,j,:))
         enddo
      enddo
   CASE(4)
@@ -61,31 +61,31 @@ SUBROUTINE uderiv(type,atom)
      DO k = 1, l
         h1 = 1./(dfzT(k)*dfzW(k))
         h2 = 1./(dfzT(k)*dfzW(k-1))
-        atom(:,:,k,14) = h2*rdz2i
-        atom(:,:,k,23) = h1*rdz2i
-        atom(:,:,k,5) = -(atom(:,:,k,14) + atom(:,:,k,23))
+        atom(14,:,:,k) = h2*rdz2i
+        atom(23,:,:,k) = h1*rdz2i
+        atom(5,:,:,k) = -(atom(14,:,:,k) + atom(23,:,:,k))
      ENDDO
   CASE(5)
      tand2 = 1 - tan(yv)*tan(yv)
      DO j = 1, m-1
-        atom(:,j,:,5) = bmh(yv(j),ih)*tand2(j)+tan(yv(j))*bmhy(yv(j),ih)
+        atom(5,:,j,:) = bmh(yv(j),ih)*tand2(j)+tan(yv(j))*bmhy(yv(j),ih)
      ENDDO
   CASE(6)
      tand2 = tan(yv)
      cosd2 = cos(yv)
      DO j = 1, m-1
-        atom(:,j,:,2)=(bmhy(yv(j),ih)-(amh(yv(j),ih)+bmh(yv(j),ih))*tand2(j))/(dx*cosd2(j))
-        atom(:,j,:,8)=-(bmhy(yv(j),ih)-(amh(yv(j),ih)+bmh(yv(j),ih))*tand2(j))/(dx*cosd2(j))
+        atom(2,:,j,:)=(bmhy(yv(j),ih)-(amh(yv(j),ih)+bmh(yv(j),ih))*tand2(j))/(dx*cosd2(j))
+        atom(8,:,j,:)=-(bmhy(yv(j),ih)-(amh(yv(j),ih)+bmh(yv(j),ih))*tand2(j))/(dx*cosd2(j))
      ENDDO
   CASE(7)
      IF (itopo.eq.3) then
         DO i = 18,20
            DO j=14,16
-              atom(i,j,:,5) = 1.0
+              atom(5,i,j,:) = 1.0
            enddo
         enddo
      ELSE
-        atom(:,:,:,5) = 1.0
+        atom(5,:,:,:) = 1.0
      ENDIF
   END SELECT
 
@@ -100,7 +100,7 @@ SUBROUTINE vderiv(type,atom)
   !     4:  vzz
   !     IMPORT/EXPORT
   integer type,i,j,k
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   real    cosdx2i(0:m),dy2i,rdz2i,cosd2(0:m),tand2(0:m)
   real    h1,h2
   real    amh,bmh,bmhy
@@ -111,20 +111,20 @@ SUBROUTINE vderiv(type,atom)
      IF (itopo.eq.3) then
         DO i = 18,20
            DO j=1,3
-              atom(i,j,:,5) = 1.0
+              atom(5,i,j,:) = 1.0
            enddo
         enddo
      ELSE
-        atom(:,:,:,5) = 1.0
+        atom(5,:,:,:) = 1.0
      ENDIF
   CASE(2)
      ! vxx
      cosdx2i = (1.0/(cos(yv)*dx))**2
      do i=1,n
         do j = 1, m -1
-           atom(i,j,:,2) = bmh(yv(j),ih)*cosdx2i(j)
-           atom(i,j,:,5) =-2*bmh(yv(j),ih)*cosdx2i(j)
-           atom(i,j,:,8) = bmh(yv(j),ih)*cosdx2i(j)
+           atom(2,i,j,:) = bmh(yv(j),ih)*cosdx2i(j)
+           atom(5,i,j,:) =-2*bmh(yv(j),ih)*cosdx2i(j)
+           atom(8,i,j,:) = bmh(yv(j),ih)*cosdx2i(j)
         enddo
      enddo
   CASE(3)
@@ -132,9 +132,9 @@ SUBROUTINE vderiv(type,atom)
      dy2i = (1.0/dy)**2
      do i=1,n
         do j=1,m-1
-           atom(i,j,:,4) = dy2i* amh(y(j),ih)*cos(y(j))/cos(yv(j))
-           atom(i,j,:,6) = dy2i* amh(y(j+1),ih)*cos(y(j+1))/cos(yv(j))
-           atom(i,j,:,5) =-(atom(i,j,:,4) + atom(i,j,:,6))
+           atom(4,i,j,:) = dy2i* amh(y(j),ih)*cos(y(j))/cos(yv(j))
+           atom(6,i,j,:) = dy2i* amh(y(j+1),ih)*cos(y(j+1))/cos(yv(j))
+           atom(5,i,j,:) =-(atom(4,i,j,:) + atom(6,i,j,:))
         enddo
      enddo
   CASE(4)
@@ -142,30 +142,30 @@ SUBROUTINE vderiv(type,atom)
      DO k = 1, l
         h1 = 1./(dfzT(k)*dfzW(k))
         h2 = 1./(dfzT(k)*dfzW(k-1))
-        atom(:,:,k,14) = h2*rdz2i
-        atom(:,:,k,23) = h1*rdz2i
-        atom(:,:,k,5) = -(atom(:,:,k,14) + atom(:,:,k,23))
+        atom(14,:,:,k) = h2*rdz2i
+        atom(23,:,:,k) = h1*rdz2i
+        atom(5,:,:,k) = -(atom(14,:,:,k) + atom(23,:,:,k))
      ENDDO
   CASE(5)
      DO j = 1, m-1
-        atom(:,j,:,5)=bmh(yv(j),ih)-amh(yv(j),ih)*tan(yv(j))*tan(yv(j))+bmhy(yv(j),ih)*tan(yv(j))
+        atom(5,:,j,:)=bmh(yv(j),ih)-amh(yv(j),ih)*tan(yv(j))*tan(yv(j))+bmhy(yv(j),ih)*tan(yv(j))
      ENDDO
   CASE(6)
      tand2 = tan(yv)
      cosd2 = cos(yv)
      DO j = 1, m-1
-        atom(:,j,:,2)=-((amh(yv(j),ih)+bmh(yv(j),ih))*tand2(j)-bmhy(yv(j),ih))/(dx*cosd2(j))
-        atom(:,j,:,8)= ((amh(yv(j),ih)+bmh(yv(j),ih))*tand2(j)-bmhy(yv(j),ih))/(dx*cosd2(j))
+        atom(2,:,j,:)=-((amh(yv(j),ih)+bmh(yv(j),ih))*tand2(j)-bmhy(yv(j),ih))/(dx*cosd2(j))
+        atom(8,:,j,:)= ((amh(yv(j),ih)+bmh(yv(j),ih))*tand2(j)-bmhy(yv(j),ih))/(dx*cosd2(j))
      ENDDO
   CASE(7)
      IF (itopo.eq.3) then
         DO i = 18,20
            DO j=14,16
-              atom(i,j,:,5) = 1.0
+              atom(5,i,j,:) = 1.0
            enddo
         enddo
      ELSE
-        atom(:,:,:,5) = 1.0
+        atom(5,:,:,:) = 1.0
      ENDIF
   END SELECT
 
@@ -179,7 +179,7 @@ SUBROUTINE pderiv(type,atom)
   !     3:  wz
   !     IMPORT/EXPORT
   integer type,i,j,k
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   real    cos2i(0:m+1),cos2v(0:m),dzi
 
   !
@@ -189,10 +189,10 @@ SUBROUTINE pderiv(type,atom)
      cos2i = 1.0/(2*cos(y)*dx)
      do j = 1, m
         do i= 1, n
-           atom(i,j,:,2) =-cos2i(j)
-           atom(i,j,:,4) = cos2i(j)
-           atom(i,j,:,1) =-cos2i(j)
-           atom(i,j,:,5) = cos2i(j)
+           atom(2,i,j,:) =-cos2i(j)
+           atom(4,i,j,:) = cos2i(j)
+           atom(1,i,j,:) =-cos2i(j)
+           atom(5,i,j,:) = cos2i(j)
         enddo
      enddo
   CASE(2)
@@ -200,23 +200,23 @@ SUBROUTINE pderiv(type,atom)
      cos2i = 1./(2*cos(y)*dy)
      do j = 1, m
         do i= 1, n
-           atom(i,j,:,4) = - cos2v(j-1) * cos2i(j)
-           atom(i,j,:,2) =   cos2v(j) * cos2i(j)
-           atom(i,j,:,1) = - cos2v(j-1) * cos2i(j)
-           atom(i,j,:,5) =   cos2v(j) * cos2i(j)
+           atom(4,i,j,:) = - cos2v(j-1) * cos2i(j)
+           atom(2,i,j,:) =   cos2v(j) * cos2i(j)
+           atom(1,i,j,:) = - cos2v(j-1) * cos2i(j)
+           atom(5,i,j,:) =   cos2v(j) * cos2i(j)
         enddo
      enddo
   CASE(3)
      dzi = 1.0/dz
      do k = 1, l
-        atom(:,:,k,5) = dzi/dfzT(k)
-        atom(:,:,k,14) =-dzi/dfzT(k)
+        atom(5,:,:,k) = dzi/dfzT(k)
+        atom(14,:,:,k) =-dzi/dfzT(k)
      enddo
   END SELECT
 
   ! scale continuity equation with constant factor
   !      DO k = 1,l
-  !        atom(:,:,k,:) = atom(:,:,k,:) * dfzT(k)
+  !        atom(:,:,:,k) = atom(:,:,:,k) * dfzT(k)
   !      END DO
 
 
@@ -232,7 +232,7 @@ SUBROUTINE tderiv(type,atom)
   !     6:  tzz
   !     IMPORT/EXPORT
   integer type
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   ! LOCAL
   integer i,j,k
   real    cosdx2i(0:m+1),dy2i,dz2i,h1,h2
@@ -240,18 +240,18 @@ SUBROUTINE tderiv(type,atom)
   atom = 0.0
   SELECT CASE(type)
   CASE(1) ! surface central points
-     atom(:,:,L,5) = 1.0
-     if(la > 0) atom(:,:,L,23) = -1.0 ! atmosphere
+     atom(5,:,:,L) = 1.0
+     if(la > 0) atom(23,:,:,L) = -1.0 ! atmosphere
   CASE(2) ! surface central points
-     atom(:,:,L,5) = 1.0
+     atom(5,:,:,L) = 1.0
   CASE(3)
      cosdx2i = (1.0/(cos(y)*dx))**2
      do i=1,n
         do j=1,m
            do k=1,l
-              atom(i,j,k,2) = cosdx2i(j)*(1 - landm(i,j,l))
-              atom(i,j,k,5) =-2*cosdx2i(j)*(1 - landm(i,j,l))
-              atom(i,j,k,8) = cosdx2i(j)*(1 - landm(i,j,l))
+              atom(2,i,j,k) = cosdx2i(j)*(1 - landm(i,j,l))
+              atom(5,i,j,k) =-2*cosdx2i(j)*(1 - landm(i,j,l))
+              atom(8,i,j,k) = cosdx2i(j)*(1 - landm(i,j,l))
            enddo
         enddo
      enddo
@@ -260,9 +260,9 @@ SUBROUTINE tderiv(type,atom)
      do i=1,n
         do k = 1, l
            do j = 1, m
-              atom(i,j,k,4) = (dy2i * cos(yv(j-1)) / cos(y(j)))*(1 - landm(i,j,l))
-              atom(i,j,k,6) = (dy2i * cos(yv(j)) / cos(y(j)))*(1 - landm(i,j,l))
-              atom(i,j,k,5) = -(atom(i,j,k,4) + atom(i,j,k,6))
+              atom(4,i,j,k) = (dy2i * cos(yv(j-1)) / cos(y(j)))*(1 - landm(i,j,l))
+              atom(6,i,j,k) = (dy2i * cos(yv(j)) / cos(y(j)))*(1 - landm(i,j,l))
+              atom(5,i,j,k) = -(atom(4,i,j,k) + atom(6,i,j,k))
            enddo
         enddo
      enddo
@@ -273,9 +273,9 @@ SUBROUTINE tderiv(type,atom)
         h2 = 1./(dfzT(k)*dfzW(k-1))
         do j=1,m
            do i=1,n
-              atom(i,j,k,14) = h2*dz2i*(1 - landm(i,j,l))
-              atom(i,j,k,23) = h1*dz2i*(1 - landm(i,j,l))
-              atom(i,j,k,5) = -(atom(i,j,k,14) + atom(i,j,k,23))
+              atom(14,i,j,k) = h2*dz2i*(1 - landm(i,j,l))
+              atom(23,i,j,k) = h1*dz2i*(1 - landm(i,j,l))
+              atom(5,i,j,k) = -(atom(14,i,j,k) + atom(23,i,j,k))
            enddo
         enddo
      enddo
@@ -284,22 +284,22 @@ SUBROUTINE tderiv(type,atom)
      h2 = 1./(dfzT(k)*dfzW(k-1))
      do i=1,n
         do j=1,m
-           atom(i,j,k,14) = h2*dz2i*(1 - landm(i,j,l))
-           atom(i,j,k,23) = 0.0
-           atom(i,j,k,5)  = -(atom(i,j,k,14) + atom(i,j,k,23))
+           atom(14,i,j,k) = h2*dz2i*(1 - landm(i,j,l))
+           atom(23,i,j,k) = 0.0
+           atom(5,i,j,k)  = -(atom(14,i,j,k) + atom(23,i,j,k))
         enddo
      enddo
   CASE(6)
      DO i = 1,n
         DO j = 1,m
            DO k = 1,l
-              atom(i,j,k,23) = 1.0 * (1 - landm(i,j,l))
-              atom(i,j,k,5) = 1.0 * (1 - landm(i,j,l))
+              atom(23,i,j,k) = 1.0 * (1 - landm(i,j,l))
+              atom(5,i,j,k) = 1.0 * (1 - landm(i,j,l))
            ENDDO
         ENDDO
      ENDDO
   CASE(7)
-     atom(:,:,1,5) = 1.0
+     atom(5,:,:,1) = 1.0
   END SELECT
 
 end SUBROUTINE tderiv
@@ -315,7 +315,7 @@ SUBROUTINE coriolis(type,atom)
   !                                          *     i  i+1
   !     IMPORT/EXPORT                        *  i-1  i
   integer type
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   !     LOCAL
   integer i,j
   real      corv(0:m)
@@ -325,13 +325,13 @@ SUBROUTINE coriolis(type,atom)
   if (type.EQ.1) then
      do i=1,n
         do j=1,m-1
-           atom(i,j,:,5) = corv(j)
+           atom(5,i,j,:) = corv(j)
         enddo
      enddo
   else if (type.EQ.2) then
      do i=1,n
         do j=1,m-1
-           atom(i,j,:,5) = corv(j)
+           atom(5,i,j,:) = corv(j)
         enddo
      enddo
   end if
@@ -344,7 +344,7 @@ SUBROUTINE gradp(type,atom)
   implicit none
   !     IMPORT/EXPORT
   integer type
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   !     LOCAL
   integer i,j,k
   real    cosdxi(0:m),dyi,dzi
@@ -355,27 +355,27 @@ SUBROUTINE gradp(type,atom)
      cosdxi = 1./(2*cos(yv)*dx)
      do i=1,n
         do j = 1, m -1
-           atom(i,j,:,5) =-cosdxi(j)
-           atom(i,j,:,6) =-cosdxi(j)
-           atom(i,j,:,8) = cosdxi(j)
-           atom(i,j,:,9) = cosdxi(j)
+           atom(5,i,j,:) =-cosdxi(j)
+           atom(6,i,j,:) =-cosdxi(j)
+           atom(8,i,j,:) = cosdxi(j)
+           atom(9,i,j,:) = cosdxi(j)
         enddo
      enddo
   CASE(2)
      dyi = 1./(2*dy)
      do i=1,n
         do j = 1, m -1
-           atom(i,j,:,5) =-dyi
-           atom(i,j,:,8) =-dyi
-           atom(i,j,:,6) = dyi
-           atom(i,j,:,9) = dyi
+           atom(5,i,j,:) =-dyi
+           atom(8,i,j,:) =-dyi
+           atom(6,i,j,:) = dyi
+           atom(9,i,j,:) = dyi
         enddo
      enddo
   CASE(3)
      dzi = 1./dz
      do k = 1, l
-        atom(:,:,k,5) =-dzi/dfzW(k)
-        atom(:,:,k,23) = dzi/dfzW(k)
+        atom(5,:,:,k) =-dzi/dfzW(k)
+        atom(23,:,:,k) = dzi/dfzW(k)
      enddo
   END SELECT
 
@@ -387,11 +387,11 @@ SUBROUTINE masksi(atom, mask)
   ! sea ice mask atom
 
   ! IMPORT/EXPORT
-  real atom(n,m,l,np)
+  real atom(np,n,m,l)
   real mask(1:n, 1:m)
 
   atom = 0.0;
-  atom(:,:,l,5) = mask;
+  atom(5,:,:,l) = mask;
 
 end SUBROUTINE masksi
 
@@ -417,7 +417,7 @@ SUBROUTINE tnlin(type,atom,u,v,w,t,s)
   !
   ! IMPORT/EXPORT
   integer type
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   real    u(0:n  ,0:m,0:l+la+1),   v(0:n,0:m  ,0:l+la+1)
   real    w(0:n+1,0:m+1,0:l+la)
   real    t(0:n+1,0:m+1,0:l+la+1), s(0:n+1,0:m+1,0:l+la+1)
@@ -437,17 +437,17 @@ SUBROUTINE tnlin(type,atom,u,v,w,t,s)
   SELECT CASE(type)
   CASE(1)                   ! trT
      ! coefficienten voor u met T als basis; hier niet gebruikt.
-     atom(:,:,:,5) =1.0
+     atom(5,:,:,:) =1.0
   CASE(2)                   ! urTx
      ! coefficienten voor u met T als basis; hier alleen voor i-1,j (1) en i,j (4)
      costdxi = 1.0/(4*cos(y)*dx)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,2) = -(t(i,j,k)+t(i-1,j,k))*costdxi(j)*(1 - landm(i,j,l))
-              atom(i,j,k,4) =  (t(i+1,j,k)+t(i,j,k))*costdxi(j)*(1 - landm(i,j,l))
-              atom(i,j,k,1) = -(t(i,j,k)+t(i-1,j,k))*costdxi(j)*(1 - landm(i,j,l))
-              atom(i,j,k,5) =  (t(i+1,j,k)+t(i,j,k))*costdxi(j)*(1 - landm(i,j,l))
+              atom(2,i,j,k) = -(t(i,j,k)+t(i-1,j,k))*costdxi(j)*(1 - landm(i,j,l))
+              atom(4,i,j,k) =  (t(i+1,j,k)+t(i,j,k))*costdxi(j)*(1 - landm(i,j,l))
+              atom(1,i,j,k) = -(t(i,j,k)+t(i-1,j,k))*costdxi(j)*(1 - landm(i,j,l))
+              atom(5,i,j,k) =  (t(i+1,j,k)+t(i,j,k))*costdxi(j)*(1 - landm(i,j,l))
            ENDDO
         ENDDO
      ENDDO
@@ -457,9 +457,9 @@ SUBROUTINE tnlin(type,atom,u,v,w,t,s)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,2) = -(u(i-1,j,k)+u(i-1,j-1,k))*costdxi(j)*(1 - landm(i,j,l))
-              atom(i,j,k,8) = (u(i,j,k)+u(i,j-1,k))*costdxi(j)*(1 - landm(i,j,l))
-              atom(i,j,k,5) = atom(i,j,k,2) + atom(i,j,k,8)
+              atom(2,i,j,k) = -(u(i-1,j,k)+u(i-1,j-1,k))*costdxi(j)*(1 - landm(i,j,l))
+              atom(8,i,j,k) = (u(i,j,k)+u(i,j-1,k))*costdxi(j)*(1 - landm(i,j,l))
+              atom(5,i,j,k) = atom(2,i,j,k) + atom(8,i,j,k)
            ENDDO
         ENDDO
      ENDDO
@@ -469,10 +469,10 @@ SUBROUTINE tnlin(type,atom,u,v,w,t,s)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,4) = -costdxi(j)*(t(i,j,k)+t(i,j-1,k))*cos(yv(j-1))*(1 - landm(i,j,l))
-              atom(i,j,k,1) = -costdxi(j)*(t(i,j,k)+t(i,j-1,k))*cos(yv(j-1))*(1 - landm(i,j,l))
-              atom(i,j,k,5) = costdxi(j)*(t(i,j+1,k)+t(i,j,k))*cos(yv(j))*(1 - landm(i,j,l))
-              atom(i,j,k,2) = costdxi(j)*(t(i,j+1,k)+t(i,j,k))*cos(yv(j))*(1 - landm(i,j,l))
+              atom(4,i,j,k) = -costdxi(j)*(t(i,j,k)+t(i,j-1,k))*cos(yv(j-1))*(1 - landm(i,j,l))
+              atom(1,i,j,k) = -costdxi(j)*(t(i,j,k)+t(i,j-1,k))*cos(yv(j-1))*(1 - landm(i,j,l))
+              atom(5,i,j,k) = costdxi(j)*(t(i,j+1,k)+t(i,j,k))*cos(yv(j))*(1 - landm(i,j,l))
+              atom(2,i,j,k) = costdxi(j)*(t(i,j+1,k)+t(i,j,k))*cos(yv(j))*(1 - landm(i,j,l))
            ENDDO
         ENDDO
      ENDDO
@@ -482,9 +482,9 @@ SUBROUTINE tnlin(type,atom,u,v,w,t,s)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,4) = -(v(i,j-1,k)+v(i-1,j-1,k))*costdxi(j)*cos(yv(j-1))*(1 - landm(i,j,l))
-              atom(i,j,k,6) = (v(i,j,k)+v(i-1,j,k))*costdxi(j)*cos(yv(j))*(1 - landm(i,j,l))
-              atom(i,j,k,5) = atom(i,j,k,4) + atom(i,j,k,6)
+              atom(4,i,j,k) = -(v(i,j-1,k)+v(i-1,j-1,k))*costdxi(j)*cos(yv(j-1))*(1 - landm(i,j,l))
+              atom(6,i,j,k) = (v(i,j,k)+v(i-1,j,k))*costdxi(j)*cos(yv(j))*(1 - landm(i,j,l))
+              atom(5,i,j,k) = atom(4,i,j,k) + atom(6,i,j,k)
            ENDDO
         ENDDO
      ENDDO
@@ -494,12 +494,12 @@ SUBROUTINE tnlin(type,atom,u,v,w,t,s)
      DO j = 1, m
         DO i = 1, n
            DO k = 1, l-1
-              atom(i,j,k,14) = -tdzi*(1 - landm(i,j,l))*(t(i,j,k)+t(i,j,k-1))/dfzT(k)
-              atom(i,j,k,5) = tdzi*(1 - landm(i,j,l))*(t(i,j,k+1)+t(i,j,k))/dfzT(k)
+              atom(14,i,j,k) = -tdzi*(1 - landm(i,j,l))*(t(i,j,k)+t(i,j,k-1))/dfzT(k)
+              atom(5,i,j,k) = tdzi*(1 - landm(i,j,l))*(t(i,j,k+1)+t(i,j,k))/dfzT(k)
            ENDDO
            k = l
-           atom(i,j,k,14) = -tdzi*(1 - landm(i,j,l))*(t(i,j,k)+t(i,j,k-1))/dfzT(k)
-           atom(i,j,k,5) = 0.0
+           atom(14,i,j,k) = -tdzi*(1 - landm(i,j,l))*(t(i,j,k)+t(i,j,k-1))/dfzT(k)
+           atom(5,i,j,k) = 0.0
         ENDDO
      ENDDO
   CASE(7)                   ! Wtrz
@@ -508,10 +508,10 @@ SUBROUTINE tnlin(type,atom,u,v,w,t,s)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,14) = -w(i,j,k-1)*(1 - landm(i,j,l))*tdzi/dfzT(k)
-              atom(i,j,k,23) = w(i,j,k)*(1 - landm(i,j,l))*tdzi/dfzT(k)
+              atom(14,i,j,k) = -w(i,j,k-1)*(1 - landm(i,j,l))*tdzi/dfzT(k)
+              atom(23,i,j,k) = w(i,j,k)*(1 - landm(i,j,l))*tdzi/dfzT(k)
 
-              atom(i,j,k,5) =  atom(i,j,k,14) + atom(i,j,k,23)
+              atom(5,i,j,k) =  atom(14,i,j,k) + atom(23,i,j,k)
            ENDDO
         ENDDO
      ENDDO
@@ -528,7 +528,7 @@ SUBROUTINE wnlin(type,atom,t)
   !
   !     IMPORT/EXPORT
   integer type
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   real    t(0:n+1,0:m+1,0:l+la+1)
   ! LOCAL
   integer i,j,k
@@ -540,8 +540,8 @@ SUBROUTINE wnlin(type,atom,t)
      DO k = 1,l-1
         DO j = 1,m
            DO i = 1,n
-              atom(i,j,k,23) = (t(i,j,k)+t(i,j,k+1))/2.
-              atom(i,j,k,5) = (t(i,j,k)+t(i,j,k+1))/2.
+              atom(23,i,j,k) = (t(i,j,k)+t(i,j,k+1))/2.
+              atom(5,i,j,k) = (t(i,j,k)+t(i,j,k+1))/2.
            ENDDO
         ENDDO
      ENDDO
@@ -549,8 +549,8 @@ SUBROUTINE wnlin(type,atom,t)
      DO k = 1,l-1
         DO j = 1,m
            DO i = 1,n
-              atom(i,j,k,23) = t(i,j,k+1)/4.
-              atom(i,j,k,5) = (t(i,j,k)+2*t(i,j,k+1))/4.
+              atom(23,i,j,k) = t(i,j,k+1)/4.
+              atom(5,i,j,k) = (t(i,j,k)+2*t(i,j,k+1))/4.
            ENDDO
         ENDDO
      ENDDO
@@ -558,8 +558,8 @@ SUBROUTINE wnlin(type,atom,t)
      DO k=1,l-1
         DO j = 1,m
            DO i = 1,n
-              atom(i,j,k,5) = 0.375*(t(i,j,k)+t(i,j,k+1))**2
-              atom(i,j,k,23) = 0.375*(t(i,j,k)+t(i,j,k+1))**2
+              atom(5,i,j,k) = 0.375*(t(i,j,k)+t(i,j,k+1))**2
+              atom(23,i,j,k) = 0.375*(t(i,j,k)+t(i,j,k+1))**2
            ENDDO
         ENDDO
      ENDDO
@@ -567,10 +567,10 @@ SUBROUTINE wnlin(type,atom,t)
      DO k=1,l-1
         DO j = 1,m
            DO i = 1,n
-              atom(i,j,k,5) = 0.125*(t(i,j,k)*t(i,j,k)+&
+              atom(5,i,j,k) = 0.125*(t(i,j,k)*t(i,j,k)+&
                    3*t(i,j,k+1)*t(i,j,k) +&
                    3*t(i,j,k+1)*t(i,j,k+1))
-              atom(i,j,k,23) = 0.125*t(i,j,k+1)*t(i,j,k+1)
+              atom(23,i,j,k) = 0.125*t(i,j,k+1)*t(i,j,k+1)
            ENDDO
         ENDDO
      ENDDO
@@ -594,7 +594,7 @@ SUBROUTINE unlin(type,atom,u,v,w)
   !
   ! IMPORT/EXPORT
   integer type
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   real    u(0:n  ,0:m,0:l+la+1),   v(0:n,0:m  ,0:l+la+1)
   real    w(0:n+1,0:m+1,0:l+la  )
 
@@ -609,10 +609,10 @@ SUBROUTINE unlin(type,atom,u,v,w)
      DO j = 1, m
         DO k = 1, l
            DO i = 1, n-1
-              atom(i,j,k,8) = u(i+1,j,k)*costdxi(j)
+              atom(8,i,j,k) = u(i+1,j,k)*costdxi(j)
            ENDDO
            DO i = 2,n
-              atom(i,j,k,2) = - u(i-1,j,k)*costdxi(j)
+              atom(2,i,j,k) = - u(i-1,j,k)*costdxi(j)
            ENDDO
         ENDDO
      ENDDO
@@ -621,10 +621,10 @@ SUBROUTINE unlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n-1
-              atom(i,j,k,8) = 2*u(i+1,j,k)*costdxi(j)
+              atom(8,i,j,k) = 2*u(i+1,j,k)*costdxi(j)
            ENDDO
            DO i=2,n
-              atom(i,j,k,2) = - 2*u(i-1,j,k)*costdxi(j)
+              atom(2,i,j,k) = - 2*u(i-1,j,k)*costdxi(j)
            ENDDO
         ENDDO
      ENDDO
@@ -633,10 +633,10 @@ SUBROUTINE unlin(type,atom,u,v,w)
      DO k = 1, l
         DO i = 1, n
            DO j = 2, m
-              atom(i,j,k,4) = -v(i,j-1,k)*cos(yv(j-1))*costdxi(j)
+              atom(4,i,j,k) = -v(i,j-1,k)*cos(yv(j-1))*costdxi(j)
            ENDDO
            DO j=1,m-1
-              atom(i,j,k,6) =  v(i,j+1,k)*cos(yv(j+1))*costdxi(j)
+              atom(6,i,j,k) =  v(i,j+1,k)*cos(yv(j+1))*costdxi(j)
            ENDDO
         ENDDO
      ENDDO
@@ -645,10 +645,10 @@ SUBROUTINE unlin(type,atom,u,v,w)
      DO k = 1, l
         DO i = 1, n
            DO j = 2, m
-              atom(i,j,k,4) =  -u(i,j-1,k)*cos(yv(j-1))*costdxi(j)
+              atom(4,i,j,k) =  -u(i,j-1,k)*cos(yv(j-1))*costdxi(j)
            ENDDO
            DO j=1,m-1
-              atom(i,j,k,6) =    u(i,j+1,k)*cos(yv(j+1))*costdxi(j)
+              atom(6,i,j,k) =    u(i,j+1,k)*cos(yv(j+1))*costdxi(j)
            ENDDO
         ENDDO
      ENDDO
@@ -657,9 +657,9 @@ SUBROUTINE unlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,23) =  (w(i,j,k)+w(i,j+1,k)+w(i+1,j,k)+w(i+1,j+1,k))*tdzi(k)
-              atom(i,j,k,14) = -(w(i,j,k-1)+w(i,j+1,k-1)+w(i+1,j,k-1)+w(i+1,j+1,k-1))*tdzi(k)
-              atom(i,j,k,5) = atom(i,j,k,14) + atom(i,j,k,23)
+              atom(23,i,j,k) =  (w(i,j,k)+w(i,j+1,k)+w(i+1,j,k)+w(i+1,j+1,k))*tdzi(k)
+              atom(14,i,j,k) = -(w(i,j,k-1)+w(i,j+1,k-1)+w(i+1,j,k-1)+w(i+1,j+1,k-1))*tdzi(k)
+              atom(5,i,j,k) = atom(14,i,j,k) + atom(23,i,j,k)
            ENDDO
         ENDDO
      ENDDO
@@ -668,14 +668,14 @@ SUBROUTINE unlin(type,atom,u,v,w)
      DO j = 1, m
         DO i = 1, n
            DO k = 1, l
-              atom(i,j,k,5)  = (u(i,j,k) + u(i,j,k+1))*tdzi(k)
-              atom(i,j,k,6)  = (u(i,j,k) + u(i,j,k+1))*tdzi(k)
-              atom(i,j,k,8)  = (u(i,j,k) + u(i,j,k+1))*tdzi(k)
-              atom(i,j,k,9)  = (u(i,j,k) + u(i,j,k+1))*tdzi(k)
-              atom(i,j,k,14) = - (u(i,j,k) + u(i,j,k-1))*tdzi(k)
-              atom(i,j,k,15) = - (u(i,j,k) + u(i,j,k-1))*tdzi(k)
-              atom(i,j,k,17) = - (u(i,j,k) + u(i,j,k-1))*tdzi(k)
-              atom(i,j,k,18) = - (u(i,j,k) + u(i,j,k-1))*tdzi(k)
+              atom(5,i,j,k)  = (u(i,j,k) + u(i,j,k+1))*tdzi(k)
+              atom(6,i,j,k)  = (u(i,j,k) + u(i,j,k+1))*tdzi(k)
+              atom(8,i,j,k)  = (u(i,j,k) + u(i,j,k+1))*tdzi(k)
+              atom(9,i,j,k)  = (u(i,j,k) + u(i,j,k+1))*tdzi(k)
+              atom(14,i,j,k) = - (u(i,j,k) + u(i,j,k-1))*tdzi(k)
+              atom(15,i,j,k) = - (u(i,j,k) + u(i,j,k-1))*tdzi(k)
+              atom(17,i,j,k) = - (u(i,j,k) + u(i,j,k-1))*tdzi(k)
+              atom(18,i,j,k) = - (u(i,j,k) + u(i,j,k-1))*tdzi(k)
            ENDDO
         ENDDO
      ENDDO
@@ -684,7 +684,7 @@ SUBROUTINE unlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,5) = v(i,j,k)*tanr(j)
+              atom(5,i,j,k) = v(i,j,k)*tanr(j)
            ENDDO
         ENDDO
      ENDDO
@@ -693,7 +693,7 @@ SUBROUTINE unlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,5) = u(i,j,k)*tanr(j)
+              atom(5,i,j,k) = u(i,j,k)*tanr(j)
            ENDDO
         ENDDO
      ENDDO
@@ -717,7 +717,7 @@ SUBROUTINE vnlin(type,atom,u,v,w)
   !
   ! IMPORT/EXPORT
   integer type
-  real    atom(n,m,l,np)
+  real    atom(np,n,m,l)
   real    u(0:n  ,0:m,0:l+la+1),   v(0:n,0:m  ,0:l+la+1)
   real    w(0:n+1,0:m+1,0:l+la  )
 
@@ -732,10 +732,10 @@ SUBROUTINE vnlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n-1
-              atom(i,j,k,8) = u(i+1,j,k)*costdxi(j)
+              atom(8,i,j,k) = u(i+1,j,k)*costdxi(j)
            ENDDO
            DO i=2,n
-              atom(i,j,k,2) = - u(i-1,j,k)*costdxi(j)
+              atom(2,i,j,k) = - u(i-1,j,k)*costdxi(j)
            ENDDO
         ENDDO
      ENDDO
@@ -744,10 +744,10 @@ SUBROUTINE vnlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n-1
-              atom(i,j,k,8) = v(i+1,j,k)*costdxi(j)
+              atom(8,i,j,k) = v(i+1,j,k)*costdxi(j)
            ENDDO
            DO i=2,n
-              atom(i,j,k,2) = -v(i-1,j,k)*costdxi(j)
+              atom(2,i,j,k) = -v(i-1,j,k)*costdxi(j)
            ENDDO
         ENDDO
      ENDDO
@@ -756,10 +756,10 @@ SUBROUTINE vnlin(type,atom,u,v,w)
      DO k = 1, l
         DO i = 1, n
            DO j = 1, m-1
-              atom(i,j,k,6) =  v(i,j+1,k)*cos(yv(j+1))*costdxi(j)
+              atom(6,i,j,k) =  v(i,j+1,k)*cos(yv(j+1))*costdxi(j)
            ENDDO
            DO j=2,m
-              atom(i,j,k,4) = -v(i,j-1,k)*cos(yv(j-1))*costdxi(j)
+              atom(4,i,j,k) = -v(i,j-1,k)*cos(yv(j-1))*costdxi(j)
            ENDDO
         ENDDO
      ENDDO
@@ -768,10 +768,10 @@ SUBROUTINE vnlin(type,atom,u,v,w)
      DO k = 1, l
         DO i = 1, n
            DO j = 1, m-1
-              atom(i,j,k,6) =  2*v(i,j+1,k)*cos(yv(j+1))*costdxi(j)
+              atom(6,i,j,k) =  2*v(i,j+1,k)*cos(yv(j+1))*costdxi(j)
            ENDDO
            DO j=2,m
-              atom(i,j,k,4) =  -2*v(i,j-1,k)*cos(yv(j-1))*costdxi(j)
+              atom(4,i,j,k) =  -2*v(i,j-1,k)*cos(yv(j-1))*costdxi(j)
            ENDDO
         ENDDO
      ENDDO
@@ -780,9 +780,9 @@ SUBROUTINE vnlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,23) =  (w(i,j,k)+w(i,j+1,k)+w(i+1,j,k)+w(i+1,j+1,k))*tdzi(k)
-              atom(i,j,k,14) = -(w(i,j,k-1)+w(i,j+1,k-1)+w(i+1,j,k-1)+w(i+1,j+1,k-1))*tdzi(k)
-              atom(i,j,k,5) = atom(i,j,k,14) + atom(i,j,k,23)
+              atom(23,i,j,k) =  (w(i,j,k)+w(i,j+1,k)+w(i+1,j,k)+w(i+1,j+1,k))*tdzi(k)
+              atom(14,i,j,k) = -(w(i,j,k-1)+w(i,j+1,k-1)+w(i+1,j,k-1)+w(i+1,j+1,k-1))*tdzi(k)
+              atom(5,i,j,k) = atom(14,i,j,k) + atom(23,i,j,k)
            ENDDO
         ENDDO
      ENDDO
@@ -791,14 +791,14 @@ SUBROUTINE vnlin(type,atom,u,v,w)
      DO j = 1, m
         DO i = 1, n
            DO k = 1, l
-              atom(i,j,k,5) = (v(i,j,k) + v(i,j,k+1))*tdzi(k)
-              atom(i,j,k,6) = (v(i,j,k) + v(i,j,k+1))*tdzi(k)
-              atom(i,j,k,8) = (v(i,j,k) + v(i,j,k+1))*tdzi(k)
-              atom(i,j,k,9) = (v(i,j,k) + v(i,j,k+1))*tdzi(k)
-              atom(i,j,k,14) = - (v(i,j,k) + v(i,j,k-1))*tdzi(k)
-              atom(i,j,k,15) = - (v(i,j,k) + v(i,j,k-1))*tdzi(k)
-              atom(i,j,k,17) = - (v(i,j,k) + v(i,j,k-1))*tdzi(k)
-              atom(i,j,k,18) = - (v(i,j,k) + v(i,j,k-1))*tdzi(k)
+              atom(5,i,j,k) = (v(i,j,k) + v(i,j,k+1))*tdzi(k)
+              atom(6,i,j,k) = (v(i,j,k) + v(i,j,k+1))*tdzi(k)
+              atom(8,i,j,k) = (v(i,j,k) + v(i,j,k+1))*tdzi(k)
+              atom(9,i,j,k) = (v(i,j,k) + v(i,j,k+1))*tdzi(k)
+              atom(14,i,j,k) = - (v(i,j,k) + v(i,j,k-1))*tdzi(k)
+              atom(15,i,j,k) = - (v(i,j,k) + v(i,j,k-1))*tdzi(k)
+              atom(17,i,j,k) = - (v(i,j,k) + v(i,j,k-1))*tdzi(k)
+              atom(18,i,j,k) = - (v(i,j,k) + v(i,j,k-1))*tdzi(k)
            ENDDO
         ENDDO
      ENDDO
@@ -808,7 +808,7 @@ SUBROUTINE vnlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,5) = u(i,j,k)*tanr(j)
+              atom(5,i,j,k) = u(i,j,k)*tanr(j)
            ENDDO
         ENDDO
      ENDDO
@@ -818,7 +818,7 @@ SUBROUTINE vnlin(type,atom,u,v,w)
      DO k = 1, l
         DO j = 1, m
            DO i = 1, n
-              atom(i,j,k,5) = 2*u(i,j,k)*tanr(j)
+              atom(5,i,j,k) = 2*u(i,j,k)*tanr(j)
            ENDDO
         ENDDO
      ENDDO
@@ -838,7 +838,7 @@ SUBROUTINE yderiv(type,atom)
   !     6:  tzz
   !     IMPORT/EXPORT
   integer type,i,j
-  real    atom(n,m,la,np)
+  real    atom(np,n,m,la)
   real    cosdx2i(0:m+1),dy2i
 
   !
@@ -848,8 +848,8 @@ SUBROUTINE yderiv(type,atom)
      DO j = 1,m
         DO i = 1,n
            !         if(landm(i,j,l)/=LAND) then
-           atom(i,j,:,5)  = -1.0
-           atom(i,j,:,14) =  1.0
+           atom(5,i,j,:)  = -1.0
+           atom(14,i,j,:) =  1.0
            !         endif
         ENDDO
      ENDDO
@@ -857,28 +857,28 @@ SUBROUTINE yderiv(type,atom)
      cosdx2i = (1.0/(cos(y)*dx))**2
      DO j = 1,m
         DO i = 1,n
-           atom(i,j,:,2) =      dat(j) * cosdx2i(j)
-           atom(i,j,:,5) = -2 * dat(j) * cosdx2i(j)
-           atom(i,j,:,8) =      dat(j) * cosdx2i(j)
+           atom(2,i,j,:) =      dat(j) * cosdx2i(j)
+           atom(5,i,j,:) = -2 * dat(j) * cosdx2i(j)
+           atom(8,i,j,:) =      dat(j) * cosdx2i(j)
         ENDDO
      ENDDO
   CASE(3)
      dy2i = (1.0/dy)**2
      DO j = 1,m
         DO i = 1,n
-           atom(i,j,:,4) = dy2i*davt(j-1) * cos(yv(j-1)) / cos(y(j))
-           atom(i,j,:,6) = dy2i*davt(j)   * cos(yv(j))   / cos(y(j))
-           atom(i,j,:,5) = -(atom(i,j,:,4) + atom(i,j,:,6))
+           atom(4,i,j,:) = dy2i*davt(j-1) * cos(yv(j-1)) / cos(y(j))
+           atom(6,i,j,:) = dy2i*davt(j)   * cos(yv(j))   / cos(y(j))
+           atom(5,i,j,:) = -(atom(4,i,j,:) + atom(6,i,j,:))
         ENDDO
      ENDDO
   CASE(4)
-     atom(:,:,:,5) = 1.0
+     atom(5,:,:,:) = 1.0
   CASE(5)
      cosdx2i = 1.0/(2*cos(y)*dx)
      DO j = 1,m
         DO i = 1,n
-           atom(i,j,:,2) = - upa(j)*cosdx2i(j)
-           atom(i,j,:,8) =   upa(j)*cosdx2i(j)
+           atom(2,i,j,:) = - upa(j)*cosdx2i(j)
+           atom(8,i,j,:) =   upa(j)*cosdx2i(j)
         ENDDO
      ENDDO
      !

--- a/src/ocean/usr.F90
+++ b/src/ocean/usr.F90
@@ -162,11 +162,6 @@ module m_usr
   !real, parameter :: bottem   = 0.0
   !real, parameter :: botsal   = 0.0
 
-
-  !--obsolete (at least this seems to be the case) --
-  real, dimension(:,:,:),allocatable :: fricum,fricvm
-  real, dimension(:,:,:),allocatable :: pv_adj
-
   !________________________________________________________________
 
 
@@ -193,7 +188,6 @@ contains
 
     allocate(landm(0:n+1,0:m+1,0:l+la+1))
     landm=OCEAN;! in case no topology is read in
-    allocate(fricum(0:n,0:m,l),fricvm(0:n,0:m,l))
 
     allocate(Frc(ndim), taux(n,m), tauy(n,m), tx(n,m), ty(n,m))
     allocate(ft(n,m), fs(n,m), tatm(n,m), emip(n,m), spert(n,m))
@@ -216,7 +210,6 @@ contains
     internal_salt  = 0.0
     adapted_emip   = 0.0
 
-    allocate(pv_adj(n,m,0:l))
   end subroutine allocate_usr
 
   subroutine deallocate_usr()
@@ -229,7 +222,6 @@ contains
          dfzT,dfzW)
 
     deallocate(landm)
-    deallocate(fricum,fricvm)
 
     deallocate(Frc, taux, tauy, tx, ty)
     deallocate(ft, fs, tatm, emip, spert)
@@ -237,7 +229,6 @@ contains
     deallocate(msi, gsi, qsa)
     deallocate(ftlev, fslev)
     deallocate(internal_temp, internal_salt)
-    deallocate(pv_adj)
   end subroutine deallocate_usr
 
   !! can be called from C++ to get the grid arrays:

--- a/src/ocean/usr.F90
+++ b/src/ocean/usr.F90
@@ -165,8 +165,6 @@ module m_usr
 
   !--obsolete (at least this seems to be the case) --
   real, dimension(:,:,:),allocatable :: fricum,fricvm
-  real, dimension(:), allocatable    :: kapv,kaph
-  real, dimension(:,:,:),allocatable :: emix
   real, dimension(:,:,:),allocatable :: pv_adj
 
   !________________________________________________________________
@@ -192,8 +190,7 @@ contains
 
     allocate(x(n),y(0:m+1),z(l),xu(0:n),yv(0:m),zw(0:l),ze(l),zwe(l),&
          dfzT(l),dfzW(0:l))
-    
-    allocate(kapv(0:l),kaph(l),emix(n,m,0:l))
+
     allocate(landm(0:n+1,0:m+1,0:l+la+1))
     landm=OCEAN;! in case no topology is read in
     allocate(fricum(0:n,0:m,l),fricvm(0:n,0:m,l))
@@ -231,7 +228,6 @@ contains
     deallocate(x,y,z,xu,yv,zw,ze,zwe,&
          dfzT,dfzW)
 
-    deallocate(kapv,kaph,emix)
     deallocate(landm)
     deallocate(fricum,fricvm)
 

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -391,7 +391,7 @@ SUBROUTINE setsres(tmp_sres)
 end SUBROUTINE setsres
 
 !*****************************************************************************
-SUBROUTINE matrix(un, sig1, sig2)
+SUBROUTINE matrix(un)
   use, intrinsic :: iso_c_binding
   use m_usr
   use m_mix
@@ -404,9 +404,7 @@ SUBROUTINE matrix(un, sig1, sig2)
   !     sig2: w/p
   implicit none
   real(c_double),dimension(ndim) :: un
-  real(c_double) :: sig1,sig2
   real time0, time1
-  integer i,j,k,row,ii,find_row2
 
   An = Al
 
@@ -455,26 +453,6 @@ SUBROUTINE matrix(un, sig1, sig2)
   endif
   ! --------------------------------------------------------------------- ATvS-Mix
 
-  call TIMER_START('shifting' // char(0))
-  do k = 1, l+la
-     do j = 1, m
-        do i = 1, n
-           do ii = 1,nun
-              row = find_row2(i,j,k,ii)
-              An(i,j,k,5,ii,ii) = An(i,j,k,5,ii,ii) - sig1*coB(row)
-           end do
-
-           ! note that B is 0 in W/P points, but we add something there, too
-           ! to make sure the diagonal gets included in the matrix (sig2~mach.eps)
-           row = find_row2(i,j,k,WW)
-           An(i,j,k,5,WW,WW) = An(i,j,k,5,WW,WW) - sig2
-           row = find_row2(i,j,k,PP)
-           An(i,j,k,5,PP,PP) = An(i,j,k,5,PP,PP) - sig2
-        enddo
-     enddo
-  enddo
-  call TIMER_STOP('shifting' // char(0))
-  
   call boundaries
 
   call assemble

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -109,7 +109,6 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
 !       ' QSnd = ', QSnd
 
   call stpnt        !
-  call mixe         !
   call vmix_init    ! ATvS-Mix  USES LANDMASK
   call atmos_coef   !
   call forcing      ! USES LANDMASK
@@ -138,25 +137,6 @@ subroutine finalize
   close(f99)
 
 end subroutine finalize
-
-!****************************************************************************
-SUBROUTINE mixe
-  use m_usr
-  implicit none
-  integer i,j,k
-  do i=1,n
-     do j=1,m
-        emix(i,j,0) = 0.0
-        do k=1,l-1
-           emix(i,j,k)= - sin(pi*(x(i)-xmin)/(xmax-xmin))*   &
-                (cos((pi/2)*(y(j)-ymin)/(ymax-ymin)) + 0.2)         &
-                *zw(k)
-        enddo
-        emix(i,j,l) = 0.0
-     enddo
-  enddo
-  !
-end SUBROUTINE mixe
 
 !*****************************************************************************
 SUBROUTINE setparcs(param,value)

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -97,7 +97,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
      end do
   end do
 
-  call grid         
+  call grid
 
   ! When the grid is known we can set nondimensionalization
   ! coefficients for the body forcing.
@@ -107,7 +107,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
 
 !  write(*,*) 'THCM: nondim constants: QTnd = ', QTnd, &
 !       ' QSnd = ', QSnd
-  
+
   call stpnt        !
   call mixe         !
   call vmix_init    ! ATvS-Mix  USES LANDMASK
@@ -207,7 +207,7 @@ SUBROUTINE getdeps(o_Ooa, o_Os, o_nus, o_eta, o_lvsc, o_qdim, o_pqsnd)
   real pQSnd
 
   pQSnd = par(COMB) * par(SALT) * QSnd
-  
+
   o_Ooa   = Ooa
   o_Os    = Os
   o_nus   = nus
@@ -244,9 +244,9 @@ SUBROUTINE set_atmos_parameters(i_qdim, i_nuq, i_eta, i_dqso, i_eo0, i_albe0, i_
   real(c_double) i_qdim, i_nuq, i_eta, i_dqso, i_eo0, i_albe0, i_albed
   real dzne
 
-  qdim  = i_qdim 
-  nuq   = i_nuq  
-  eta   = i_eta  
+  qdim  = i_qdim
+  nuq   = i_nuq
+  eta   = i_eta
   dqso  = i_dqso
   eo0   = i_eo0
   albe0 = i_albe0
@@ -264,22 +264,22 @@ SUBROUTINE set_atmos_parameters(i_qdim, i_nuq, i_eta, i_dqso, i_eo0, i_albe0, i_
 
   call forcing
   call lin
-  
+
 end subroutine set_atmos_parameters
 
 !**********************************************************
 SUBROUTINE set_seaice_parameters(i_zeta, i_a0, i_Lf, i_s0, i_rhoo, i_qvar, i_q0)
   use, intrinsic :: iso_c_binding
-  use m_usr 
+  use m_usr
   use m_ice
   implicit none
   real(c_double) i_zeta, i_a0, i_Lf, i_s0, i_rhoo, i_qvar, i_q0
 
-  zeta = i_zeta ! combination of sea ice parameters 
+  zeta = i_zeta ! combination of sea ice parameters
   a0   = i_a0   ! freezing temperature S sensitivity
   Lf   = i_Lf   ! latent heat of fusion of ice
   Qvar = i_qvar ! typical QTsa heat flux variation
-  Q0   = i_q0   ! background QTsa 
+  Q0   = i_q0   ! background QTsa
 
   if (i_s0.ne.s0) then
      _INFO_('WARNING conflicting reference salinity s0')
@@ -417,22 +417,22 @@ SUBROUTINE matrix(un)
   !{ removing tons of things for eigen-analysis test...
 #if 0
   !Euv
-  An(:,:,:,:,UU:VV,WW) = 0.0
+  An(UU:VV,WW,:,:,:) = 0.0
   !BTS
-  An(:,:,:,:,WW,TT:SS) = 0.0
+  An(WW,TT:SS,:,:,:) = 0.0
   !Buv, Bw
-  !An(:,:,:,:,TT:SS,UU::WW) = 0.0
+  !An(TT:SS,UU::WW,:,:,:) = 0.0
   !Gw
-  !An(:,:,:,:,WW,PP) = 0.0
+  !An(:,WW,PP,:,:,:) = 0.0
   !Dw
-  !An(:,:,:,:,PP,WW) = 0.0
+  !An(:,PP,WW,:,:,:) = 0.0
 #endif
   !}
 
 
   ! ATvS-Mix ---------------------------------------------------------------------
   if (vmix_flag.ge.1) then
-     call TIMER_START('mixing' // char(0))
+     call TIMER_START('mixing jac' // char(0))
      call cpu_time(time0)
      if (vmix_out.gt.0) write(99,'(a26)')"MIX| matrix...    "
      if (vmix_out.gt.0) write(99,'(a16,i10)') 'MIX|     fix:   ', vmix_fix
@@ -449,15 +449,15 @@ SUBROUTINE matrix(un)
      call cpu_time(time1)
      vmix_time=vmix_time+time1-time0
      if (vmix_out.gt.0) write (99,'(a26, f10.3)') 'MIX|        ...matrix done', time1-time0
-     call TIMER_STOP('mixing' // char(0))
+     call TIMER_STOP('mixing jac' // char(0))
   endif
   ! --------------------------------------------------------------------- ATvS-Mix
 
   call boundaries
 
   call assemble
-  !write(*,*) "In fortran's matrix() maxval TT =", maxval(An(:,:,:,:,TT,:))
-  !write(*,*) "In fortran's matrix() maxval SS =", maxval(An(:,:,:,:,SS,:))
+  !write(*,*) "In fortran's matrix() maxval TT =", maxval(An(:,TT,:,:,:,:))
+  !write(*,*) "In fortran's matrix() maxval SS =", maxval(An(:,SS,:,:,:,:))
 
   ! call writematrhs(0.0)
 
@@ -475,7 +475,7 @@ SUBROUTINE rhs(un,B)
 
   implicit none
   real(c_double),dimension(ndim) ::    un,B
-  real mix(ndim) ! ATvS-Mix
+  real    mix(ndim) ! ATvS-Mix
   real    Au(ndim), time0, time1
   integer i,j,k,k1,row,find_row2, mode
 
@@ -489,9 +489,12 @@ SUBROUTINE rhs(un,B)
   ! call forcing          !
   call boundaries       !
   call assemble
+  call TIMER_START('matAvec' // char(0))
   call matAvec(un,Au)   !
+  call TIMER_STOP('matAvec' // char(0))
   ! ATvS-Mix ---------------------------------------------------------------------
   if (vmix_flag.ge.1) then
+     call TIMER_START('mixing rhs' // char(0))
      mode=vmix_fix
      call cpu_time(time0)
      if (vmix_out.gt.0) write(99,'(a26)')'MIX| rhs...               '
@@ -508,14 +511,17 @@ SUBROUTINE rhs(un,B)
      call cpu_time(time1)
      vmix_time=vmix_time+time1-time0
      if (vmix_out.gt.0) write (99,'(a26,f10.3)') 'MIX|    ...rhs done',time1-time0
+     call TIMER_STOP('mixing rhs' // char(0))
   endif
   ! --------------------------------------------------------------------- ATvS-Mix
 
   _DEBUG2_("p0 = ", p0) ! Residue Continuation
 
+  call TIMER_START('addition rhs' // char(0))
   B = -Au - mix + Frc - p0*(1- par(RESC))*ures
-
+  call TIMER_STOP('addition rhs' // char(0))
 #if 1
+  call TIMER_START('landmask rhs' // char(0))
   if(ires == 0) then
      DO i = 1, n
         DO j = 1, m
@@ -528,6 +534,7 @@ SUBROUTINE rhs(un,B)
         ENDDO
      ENDDO
   endif
+  call TIMER_STOP('landmask rhs' // char(0))
 #endif
 
   ! open(15,file='Frc.co')
@@ -563,17 +570,17 @@ SUBROUTINE lin
   use m_ice
   implicit none
   !     LOCAL
-  real,target :: u(n,m,l,np),uy(n,m,l,np),ucsi(n,m,l,np),&
-       &      uxx(n,m,l,np),uyy(n,m,l,np),uzz(n,m,l,np),&
-       &      uxs(n,m,l,np),fu(n,m,l,np),px(n,m,l,np)
-  real    ub(n,m,l,np),vb(n,m,l,np),sc(n,m,l,np),tcb(n,m,l,np)
-  real    yc(n,m,la,np),yc2(n,m,la,np),yxx(n,m,la,np),yyy(n,m,la,np)
+  real,target :: u(np,n,m,l),uy(np,n,m,l),ucsi(np,n,m,l),&
+       &         uxx(np,n,m,l),uyy(np,n,m,l),uzz(np,n,m,l),&
+       &         uxs(np,n,m,l),fu(np,n,m,l),px(np,n,m,l)
+  real    ub(np,n,m,l),vb(np,n,m,l),sc(np,n,m,l),tcb(np,n,m,l)
+  real    yc(np,n,m,la),yc2(np,n,m,la),yxx(np,n,m,la),yyy(np,n,m,la)
   real    EH,EV,ph,pv,Ra,lambda, bi, dedt
-  real    yadv(n,m,la,np)
+  real    yadv(np,n,m,la)
   real    xes
 
-  real    mc(n,m,l,np)
-  real    QSoa(n,m,l,np), QSos(n,m,l,np)
+  real    mc(np,n,m,l)
+  real    QSoa(np,n,m,l), QSos(np,n,m,l)
   real    pQSnd
 
   ! original version:
@@ -621,45 +628,45 @@ SUBROUTINE lin
   ! ------------------------------------------------------------------
   ! u-equation
   ! ------------------------------------------------------------------
-  call uderiv(1,ub)     
+  call uderiv(1,ub)
   call uderiv(2,uxx)
   call uderiv(3,uyy)
   call uderiv(4,uzz)
   call uderiv(5,ucsi)
   call uderiv(6,vxs)
-  call uderiv(7,u)      
+  call uderiv(7,u)
   call coriolis(1,fv)
   call gradp(1,px)
-  Al(:,:,1:l,:,UU,UU) = -EH * (uxx+uyy+ucsi) -EV * uzz ! + rintt*u ! ATvS-Mix
-  Al(:,:,1:l,:,UU,VV) = -fv - EH*vxs
-  ! Al(:,:,1:l,:,UU,VV) = - EH*vxs ! for 2DMOC case
-  Al(:,:,1:l,:,UU,PP) =  px
+  Al(:,UU,UU,:,:,1:l) = -EH * (uxx+uyy+ucsi) -EV * uzz ! + rintt*u ! ATvS-Mix
+  Al(:,UU,VV,:,:,1:l) = -fv - EH*vxs
+  ! Al(:,UU,VV,:,:,1:l) = - EH*vxs ! for 2DMOC case
+  Al(:,UU,PP,:,:,1:l) =  px
 
   ! ------------------------------------------------------------------
   ! v-equation
   ! ------------------------------------------------------------------
-  call vderiv(1,vb )    
+  call vderiv(1,vb )
   call vderiv(2,vxx)
   call vderiv(3,vyy)
   call vderiv(4,vzz)
   call vderiv(5,vcsi)
   call vderiv(6,uxs)
-  call vderiv(7,v)      
+  call vderiv(7,v)
   call coriolis(2,fu)
   call gradp(2,py)
-  Al(:,:,1:l,:,VV,UU) =  fu - EH*uxs
-  ! Al(:,:,1:l,:,VV,UU) =  - EH*uxs ! for 2dMOC case
-  Al(:,:,1:l,:,VV,VV) = -EH*(vxx + vyy + vcsi) - EV*vzz !+ rintt*v ! ATvS-Mix
-  Al(:,:,1:l,:,VV,PP) =  py
+  Al(:,VV,UU,:,:,1:l) =  fu - EH*uxs
+  ! Al(:,VV,UU,:,:,1:l) =  - EH*uxs ! for 2dMOC case
+  Al(:,VV,VV,:,:,1:l) = -EH*(vxx + vyy + vcsi) - EV*vzz !+ rintt*v ! ATvS-Mix
+  Al(:,VV,PP,:,:,1:l) =  py
 
   ! ------------------------------------------------------------------
   ! w-equation
   ! ------------------------------------------------------------------
   call gradp(3,pz)
   call tderiv(6,tbc)
-  Al(:,:,1:l,:,WW,PP) =  pz
-  Al(:,:,1:l,:,WW,TT) = -Ra *(1. + xes*alpt1) * tbc/2.
-  Al(:,:,1:l,:,WW,SS) =  lambda * Ra * tbc/2.
+  Al(:,WW,PP,:,:,1:l) =  pz
+  Al(:,WW,TT,:,:,1:l) = -Ra *(1. + xes*alpt1) * tbc/2.
+  Al(:,WW,SS,:,:,1:l) =  lambda * Ra * tbc/2.
 
   ! ------------------------------------------------------------------
   ! p-equation
@@ -667,9 +674,9 @@ SUBROUTINE lin
   call pderiv(1,uxc)
   call pderiv(2,vyc)
   call pderiv(3,wzc)
-  Al(:,:,1:l,:,PP,UU) = uxc
-  Al(:,:,1:l,:,PP,VV) = vyc
-  Al(:,:,1:l,:,PP,WW) = wzc
+  Al(:,PP,UU,:,:,1:l) = uxc
+  Al(:,PP,VV,:,:,1:l) = vyc
+  Al(:,PP,WW,:,:,1:l) = wzc
 
   ! ------------------------------------------------------------------
   ! T-equation
@@ -686,33 +693,30 @@ SUBROUTINE lin
   ! open(999, file='mc', form='unformatted', access='stream')
   ! write(999) mc
   ! close(999)
-  
+
   ! dependence of TT on TT through latent heat due to evaporation
   dedt =  lvsc * eta * qdim * (deltat / qdim) * dqso
   ! dedt = 0.0 !hack
-  
+
   ! write(*,*) 'dedt=', dedt, ' eta=', eta, ' dqso=',dqso
 
   if (la > 0) then ! deprecated local atmosphere
-
-     Al(:,:,1:l,:,TT,TT) = - ph * (txx + tyy) - pv * tzz + Ooa*tc
+     Al(:,TT,TT,:,:,1:l) = - ph * (txx + tyy) - pv * tzz + Ooa*tc
 
   else if (coupled_T.eq.1) then ! coupled with external atmos
      ! FIXME is this too much mc*tc? TEM
 
-     Al(:,:,1:l,:,TT,TT) =                &
+     Al(:,TT,TT,:,:,1:l) =                &
           - ph * (txx + tyy) - pv * tzz   & ! diffusive transport
           + Ooa  * tc                     & ! sensible heat flux
           + dedt * sc                     & ! latent heat flux
           + mc * (QTnd * zeta * tc  -     & ! correction for sea ice
           Ooa * tc - dedt * sc)
-     
-     Al(:,:,1:l,:,TT,SS) = -QTnd * zeta * a0 * mc  ! salinity dependence in
+
+     Al(:,TT,SS,:,:,1:l) = -QTnd * zeta * a0 * mc  ! salinity dependence in
                                                    ! freezing temperature
   else
-     
-     Al(:,:,1:l,:,TT,TT) = -ph * (txx + tyy) - pv * tzz + TRES*bi*tc
-     
+     Al(:,TT,TT,:,:,1:l) = -ph * (txx + tyy) - pv * tzz + TRES*bi*tc
   endif
 
   ! ------------------------------------------------------------------
@@ -722,26 +726,26 @@ SUBROUTINE lin
   ! FIXME: naming is bad and confusing
   dedt  = nus * (deltat / qdim) * dqso
   pQSnd = par(COMB) * par(SALT) * QSnd
-  
+
   ! FIXME: ugly
   if (coupled_S.eq.1) then ! coupled to atmosphere
-     Al(:,:,1:l,:,SS,SS) = - ph * (txx + tyy) - pv * tzz &
+     Al(:,SS,SS,:,:,1:l) = - ph * (txx + tyy) - pv * tzz &
           - mc * pQSnd * zeta * a0 / (rhodim * Lf)
-     
+
      ! minus sign and nondim added (we take -Au in rhs computation)
 
      QSoa = -dedt * sc            ! atmosphere to ocean salinity flux
-                                  ! internal component 
+                                  ! internal component
 
      QSos =  pQSnd * zeta / (rhodim * Lf)    ! sea ice to ocean salinity flux
                                              ! internal component
-     
+
      ! combine contributions with mask
-     Al(:,:,1:l,:,SS,TT) =   QSoa + mc * (QSos - QSoa)
+     Al(:,SS,TT,:,:,1:l) =   QSoa + mc * (QSos - QSoa)
   else
-     Al(:,:,1:l,:,SS,SS) = - ph * (txx + tyy) - pv * tzz + SRES*bi*sc
+     Al(:,SS,SS,:,:,1:l) = - ph * (txx + tyy) - pv * tzz + SRES*bi*sc
   endif
-  
+
   ! ------------------------------------------------------------------
   ! atmosphere layer
   ! ------------------------------------------------------------------
@@ -751,12 +755,12 @@ SUBROUTINE lin
      call yderiv(2,yxx)
      call yderiv(3,yyy)
      call yderiv(5,yadv)
-     Al(:,:,l+1:l+la,5,UU,UU)  =  1.
-     Al(:,:,l+1:l+la,5,VV,VV)  =  1.
-     Al(:,:,l+1:l+la,5,WW,WW)  =  1.
-     Al(:,:,l+1:l+la,5,PP,PP)  =  1.
-     Al(:,:,l+1:l+la,5,SS,SS)  =  1.
-     Al(:,:,l+1:l+la,:,TT,TT)  = - Ad * (yxx + yyy) - yc + &
+     Al(5,UU,UU,:,:,l+1:l+la)  =  1.
+     Al(5,VV,VV,:,:,l+1:l+la)  =  1.
+     Al(5,WW,WW,:,:,l+1:l+la)  =  1.
+     Al(5,PP,PP,:,:,l+1:l+la)  =  1.
+     Al(5,SS,SS,:,:,l+1:l+la)  =  1.
+     Al(:,TT,TT,:,:,l+1:l+la)  = - Ad * (yxx + yyy) - yc + &
                                    Aa * yadv + bmua*yc2
   endif
 
@@ -780,11 +784,11 @@ SUBROUTINE nlin_rhs(un)
   real    w(0:n+1,0:m+1,0:l+la  ), p(0:n+1,0:m+1,0:l+la+1)
   real    t(0:n+1,0:m+1,0:l+la+1), s(0:n+1,0:m+1,0:l+la+1)
   real    rho(0:n+1,0:m+1,0:l+la+1)
-  real,target ::    utx(n,m,l,np),vty(n,m,l,np),wtz(n,m,l,np)
-  real    t2r(n,m,l,np),t3r(n,m,l,np)
+  real,target ::    utx(np,n,m,l),vty(np,n,m,l),wtz(np,n,m,l)
+  real    t2r(np,n,m,l),t3r(np,n,m,l)
 
-  real    uux(n,m,l,np),uvy1(n,m,l,np),uwz(n,m,l,np),uvy2(n,m,l,np)
-  real    uvx(n,m,l,np),vvy(n,m,l,np),vwz(n,m,l,np),ut2(n,m,l,np)
+  real    uux(np,n,m,l),uvy1(np,n,m,l),uwz(np,n,m,l),uvy2(np,n,m,l)
+  real    uvx(np,n,m,l),vvy(np,n,m,l),vwz(np,n,m,l),ut2(np,n,m,l)
 
   real    lambda,epsr,Ra,xes,pvc1,pvc2, pv
 
@@ -814,7 +818,7 @@ SUBROUTINE nlin_rhs(un)
   call unlin(3,uvy1,u,v,w)
   call unlin(5,uwz,u,v,w)
   call unlin(7,uvy2,u,v,w)
-  An(:,:,1:l,:,UU,UU) = An(:,:,1:l,:,UU,UU) + epsr * (uux + uvy1 + uwz + uvy2)
+  An(:,UU,UU,:,:,1:l) = An(:,UU,UU,:,:,1:l) + epsr * (uux + uvy1 + uwz + uvy2)
 #endif
 
   ! ------------------------------------------------------------------
@@ -825,8 +829,8 @@ SUBROUTINE nlin_rhs(un)
   call vnlin(3,vvy,u,v,w)
   call vnlin(5,vwz,u,v,w)
   call vnlin(7,ut2,u,v,w)
-  An(:,:,1:l,:,VV,UU) = An(:,:,1:l,:,VV,UU) + epsr *ut2
-  An(:,:,1:l,:,VV,VV) = An(:,:,1:l,:,VV,VV) + epsr*(uvx + vvy + vwz)
+  An(:,VV,UU,:,:,1:l) = An(:,VV,UU,:,:,1:l) + epsr *ut2
+  An(:,VV,VV,:,:,1:l) = An(:,VV,VV,:,:,1:l) + epsr*(uvx + vvy + vwz)
 #endif
 
   ! ------------------------------------------------------------------
@@ -834,7 +838,7 @@ SUBROUTINE nlin_rhs(un)
   ! ------------------------------------------------------------------
   call wnlin(2,t2r,t)
   call wnlin(4,t3r,t)
-  An(:,:,1:l,:,WW,TT) = An(:,:,1:l,:,WW,TT) - Ra*xes*alpt2*t2r &
+  An(:,WW,TT,:,:,1:l) = An(:,WW,TT,:,:,1:l) - Ra*xes*alpt2*t2r &
                                             + Ra*xes*alpt3*t3r
 
   ! ------------------------------------------------------------------
@@ -844,7 +848,7 @@ SUBROUTINE nlin_rhs(un)
   call tnlin(3,utx,u,v,w,t,rho)
   call tnlin(5,vty,u,v,w,t,rho)
   call tnlin(7,wtz,u,v,w,t,rho)
-  An(:,:,1:l,:,TT,TT) = An(:,:,1:l,:,TT,TT)+ utx+vty+wtz        ! ATvS-Mix
+  An(:,TT,TT,:,:,1:l) = An(:,TT,TT,:,:,1:l)+ utx+vty+wtz        ! ATvS-Mix
 #endif
 
   ! ------------------------------------------------------------------
@@ -854,7 +858,7 @@ SUBROUTINE nlin_rhs(un)
   call tnlin(3,usx,u,v,w,s,rho)
   call tnlin(5,vsy,u,v,w,s,rho)
   call tnlin(7,wsz,u,v,w,s,rho)
-  An(:,:,1:l,:,SS,SS) = An(:,:,1:l,:,SS,SS)+ usx+vsy+wsz        ! ATvS-Mix
+  An(:,SS,SS,:,:,1:l) = An(:,SS,SS,:,:,1:l)+ usx+vsy+wsz        ! ATvS-Mix
 #endif
 
   call TIMER_STOP('nlin_rhs' // char(0))
@@ -879,16 +883,16 @@ SUBROUTINE nlin_jac(un)
   real    w(0:n+1,0:m+1,0:l+la  ), p(0:n+1,0:m+1,0:l+la+1)
   real    t(0:n+1,0:m+1,0:l+la+1), s(0:n+1,0:m+1,0:l+la+1)
   real    rho(0:n+1,0:m+1,0:l+la+1)
-  real,target :: urTx(n,m,l,np),Utrx(n,m,l,np),&
-       &        vrTy(n,m,l,np),Vtry(n,m,l,np)
-  real,target :: wrTz(n,m,l,np),Wtrz(n,m,l,np)
-  real    t2r(n,m,l,np),t3r(n,m,l,np)
+  real,target :: urTx(np,n,m,l),Utrx(np,n,m,l),&
+       &        vrTy(np,n,m,l),Vtry(np,n,m,l)
+  real,target :: wrTz(np,n,m,l),Wtrz(np,n,m,l)
+  real    t2r(np,n,m,l),t3r(np,n,m,l)
 
   real    lambda,epsr,Ra,xes,pvc1,pvc2,pv
-  real uvy1(n,m,l,np),uwz(n,m,l,np),uvy2(n,m,l,np)
-  real uvx(n,m,l,np),vwz(n,m,l,np)
-  real Urux(n,m,l,np),Urvy1(n,m,l,np),Urwz(n,m,l,np),Urvy2(n,m,l,np)
-  real uVrx(n,m,l,np),Vrvy(n,m,l,np),Vrwz(n,m,l,np),Urt2(n,m,l,np)
+  real uvy1(np,n,m,l),uwz(np,n,m,l),uvy2(np,n,m,l)
+  real uvx(np,n,m,l),vwz(np,n,m,l)
+  real Urux(np,n,m,l),Urvy1(np,n,m,l),Urwz(np,n,m,l),Urvy2(np,n,m,l)
+  real uVrx(np,n,m,l),Vrvy(np,n,m,l),Vrwz(np,n,m,l),Urt2(np,n,m,l)
 
   real,dimension(:,:,:,:),pointer :: urSx,Usrx,vrSy,Vsry,wrSz,Wsrz
 
@@ -923,9 +927,9 @@ SUBROUTINE nlin_jac(un)
   call unlin(6,Urwz,u,v,w)
   call unlin(7,uvy2,u,v,w)
   call unlin(8,Urvy2,u,v,w)
-  An(:,:,1:l,:,UU,UU)  =  An(:,:,1:l,:,UU,UU) + epsr * (Urux + uvy1 + uwz + uvy2)
-  An(:,:,1:l,:,UU,VV)  =  An(:,:,1:l,:,UU,VV) + epsr * (Urvy1 + Urvy2)
-  An(:,:,1:l,:,UU,WW)  =  An(:,:,1:l,:,UU,WW) + epsr *  Urwz
+  An(:,UU,UU,:,:,1:l)  =  An(:,UU,UU,:,:,1:l) + epsr * (Urux + uvy1 + uwz + uvy2)
+  An(:,UU,VV,:,:,1:l)  =  An(:,UU,VV,:,:,1:l) + epsr * (Urvy1 + Urvy2)
+  An(:,UU,WW,:,:,1:l)  =  An(:,UU,WW,:,:,1:l) + epsr *  Urwz
 #endif
 
   ! ------------------------------------------------------------------
@@ -938,9 +942,9 @@ SUBROUTINE nlin_jac(un)
   call vnlin(5,vwz,u,v,w)
   call vnlin(6,Vrwz,u,v,w)
   call vnlin(8,Urt2,u,v,w)
-  An(:,:,1:l,:,VV,UU) =   An(:,:,1:l,:,VV,UU) + epsr * (Urt2 + uVrx)
-  An(:,:,1:l,:,VV,VV) =   An(:,:,1:l,:,VV,VV) + epsr * (uvx + Vrvy + vwz)
-  An(:,:,1:l,:,VV,WW) =   An(:,:,1:l,:,VV,WW) + epsr * Vrwz
+  An(:,VV,UU,:,:,1:l) =   An(:,VV,UU,:,:,1:l) + epsr * (Urt2 + uVrx)
+  An(:,VV,VV,:,:,1:l) =   An(:,VV,VV,:,:,1:l) + epsr * (uvx + Vrvy + vwz)
+  An(:,VV,WW,:,:,1:l) =   An(:,VV,WW,:,:,1:l) + epsr * Vrwz
 #endif
 
   ! ------------------------------------------------------------------
@@ -948,7 +952,7 @@ SUBROUTINE nlin_jac(un)
   ! ------------------------------------------------------------------
   call wnlin(1,t2r,t)
   call wnlin(3,t3r,t)
-  An(:,:,1:l,:,WW,TT) = An(:,:,1:l,:,WW,TT) - Ra*xes*alpt2*t2r &
+  An(:,WW,TT,:,:,1:l) = An(:,WW,TT,:,:,1:l) - Ra*xes*alpt2*t2r &
                                             + Ra*xes*alpt3*t3r
 
   ! ------------------------------------------------------------------
@@ -961,10 +965,10 @@ SUBROUTINE nlin_jac(un)
   call tnlin(5,Vtry,u,v,w,t,rho)
   call tnlin(6,wrTz,u,v,w,t,rho)
   call tnlin(7,Wtrz,u,v,w,t,rho)
-  An(:,:,1:l,:,TT,UU) = An(:,:,1:l,:,TT,UU) + urTx
-  An(:,:,1:l,:,TT,VV) = An(:,:,1:l,:,TT,VV) + vrTy
-  An(:,:,1:l,:,TT,WW) = An(:,:,1:l,:,TT,WW) + wrTz
-  An(:,:,1:l,:,TT,TT) = An(:,:,1:l,:,TT,TT) + Utrx + Vtry + Wtrz        ! ATvS-Mix
+  An(:,TT,UU,:,:,1:l) = An(:,TT,UU,:,:,1:l) + urTx
+  An(:,TT,VV,:,:,1:l) = An(:,TT,VV,:,:,1:l) + vrTy
+  An(:,TT,WW,:,:,1:l) = An(:,TT,WW,:,:,1:l) + wrTz
+  An(:,TT,TT,:,:,1:l) = An(:,TT,TT,:,:,1:l) + Utrx + Vtry + Wtrz        ! ATvS-Mix
 #endif
 
   ! ------------------------------------------------------------------
@@ -977,10 +981,10 @@ SUBROUTINE nlin_jac(un)
   call tnlin(5,Vsry,u,v,w,s,rho)
   call tnlin(6,wrSz,u,v,w,s,rho)
   call tnlin(7,Wsrz,u,v,w,s,rho)
-  An(:,:,1:l,:,SS,UU) = An(:,:,1:l,:,SS,UU) + urSx
-  An(:,:,1:l,:,SS,VV) = An(:,:,1:l,:,SS,VV) + vrSy
-  An(:,:,1:l,:,SS,WW) = An(:,:,1:l,:,SS,WW) + wrSz
-  An(:,:,1:l,:,SS,SS) = An(:,:,1:l,:,SS,SS) + Usrx + Vsry + Wsrz
+  An(:,SS,UU,:,:,1:l) = An(:,SS,UU,:,:,1:l) + urSx
+  An(:,SS,VV,:,:,1:l) = An(:,SS,VV,:,:,1:l) + vrSy
+  An(:,SS,WW,:,:,1:l) = An(:,SS,WW,:,:,1:l) + wrSz
+  An(:,SS,SS,:,:,1:l) = An(:,SS,SS,:,:,1:l) + Usrx + Vsry + Wsrz
 #endif
 
   call TIMER_STOP('nlin_jac' // char(0))
@@ -1188,7 +1192,7 @@ SUBROUTINE atmos_coef
   Ai   = rhoa*hdima*cpa*udim/(r0dim*muoa)
   Ad   = rhoa*hdima*cpa*d0/(muoa*r0dim*r0dim)
   As   = sun0*(1 - c0)/(4*muoa)
-  
+
   Os   = sun0*c0/4*QTnd
   Ooa  = muoa*QTnd
 
@@ -1211,7 +1215,7 @@ SUBROUTINE atmos_coef
 
   ! write(*,*) 'Ocean-Atmosphere pars:     dzne=', dzne,' hdim=', hdim
   ! write(*,*) '                            nus=', nus, ' lvsc=', lvsc
-  ! write(*,*) '                            Ooa=', Ooa, ' muoa=', muoa    
+  ! write(*,*) '                            Ooa=', Ooa, ' muoa=', muoa
 
 END SUBROUTINE atmos_coef
 

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -434,6 +434,7 @@ SUBROUTINE matrix(un, sig1, sig2)
 
   ! ATvS-Mix ---------------------------------------------------------------------
   if (vmix_flag.ge.1) then
+     call TIMER_START('mixing' // char(0))
      call cpu_time(time0)
      if (vmix_out.gt.0) write(99,'(a26)')"MIX| matrix...    "
      if (vmix_out.gt.0) write(99,'(a16,i10)') 'MIX|     fix:   ', vmix_fix
@@ -450,9 +451,11 @@ SUBROUTINE matrix(un, sig1, sig2)
      call cpu_time(time1)
      vmix_time=vmix_time+time1-time0
      if (vmix_out.gt.0) write (99,'(a26, f10.3)') 'MIX|        ...matrix done', time1-time0
+     call TIMER_STOP('mixing' // char(0))
   endif
   ! --------------------------------------------------------------------- ATvS-Mix
 
+  call TIMER_START('shifting' // char(0))
   do k = 1, l+la
      do j = 1, m
         do i = 1, n
@@ -470,6 +473,7 @@ SUBROUTINE matrix(un, sig1, sig2)
         enddo
      enddo
   enddo
+  call TIMER_STOP('shifting' // char(0))
   
   call boundaries
 
@@ -808,6 +812,7 @@ SUBROUTINE nlin_rhs(un)
 
   real,dimension(:,:,:,:),pointer ::    usx,vsy,wsz
 
+  call TIMER_START('nlin_rhs' // char(0))
   usx=>utx
   vsy=>vty
   wsz=>wtz
@@ -874,6 +879,8 @@ SUBROUTINE nlin_rhs(un)
   An(:,:,1:l,:,SS,SS) = An(:,:,1:l,:,SS,SS)+ usx+vsy+wsz        ! ATvS-Mix
 #endif
 
+  call TIMER_STOP('nlin_rhs' // char(0))
+
 end SUBROUTINE nlin_rhs
 
 !****************************************************************************
@@ -906,6 +913,9 @@ SUBROUTINE nlin_jac(un)
   real uVrx(n,m,l,np),Vrvy(n,m,l,np),Vrwz(n,m,l,np),Urt2(n,m,l,np)
 
   real,dimension(:,:,:,:),pointer :: urSx,Usrx,vrSy,Vsry,wrSz,Wsrz
+
+  call TIMER_START('nlin_jac' // char(0))
+
   urSx=>urTx
   vrSy=>vrTy
   wrSz=>wrTz
@@ -994,6 +1004,8 @@ SUBROUTINE nlin_jac(un)
   An(:,:,1:l,:,SS,WW) = An(:,:,1:l,:,SS,WW) + wrSz
   An(:,:,1:l,:,SS,SS) = An(:,:,1:l,:,SS,SS) + Usrx + Vsry + Wsrz
 #endif
+
+  call TIMER_STOP('nlin_jac' // char(0))
 
 end SUBROUTINE nlin_jac
 !****************************************************************************


### PR DESCRIPTION
This pull request does two things to optimize THCM. The first is to not call `lin` and `forcing` every time the matrix or rhs is constructed, and the second is the optimization of the assemble routine. To optimize this, the indices of the 6D arrays have been swapped, which makes everything much more cache efficient.