### PR TITLE
Make JDQZPP a normal dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,20 @@ addons:
       - libsuperlu-dev
       - libptscotch-dev
 
+env:
+  - PATH=$PATH:$TRAVIS_BUILD_DIR/local/bin LIBRARY_PATH=$LIBRARY_PATH:$TRAVIS_BUILD_DIR/local/lib LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRAVIS_BUILD_DIR/local/lib
+
 cache: ccache
 
 install:
+  - git clone https://github.com/erik808/jdqzpp.git
+  - cd jdqzpp
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/local ..
+  - make
+  - make install
+  - cd ../..
   - mkdir build
   - cd build
   - cmake ..

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 | parmetis       | (`wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz`)          |
 | mrilu          | (available in this repository)                                                             |
 | Trilinos       | <https://trilinos.org/download/>  (this project is tested to work with 11.12/11.14/12.12)  |
-| jdqzpp         | (external project, fetched and installed by cmake)                                         |
+| jdqzpp         | <https://github.com/erik808/jdqzpp>                                                        |
 | gtest          | (external project, fetched and installed by cmake)                                         |
 
 ### Compilers
@@ -33,6 +33,8 @@ Depending on architecture: ifort, gfortran, mpicc, mpicpc, mpic++, etc...
 
     * Make cmake script executable and run it, install Trilinos
       * Possible failures: no lapack, blas or hdf5 libs. `hdf5-openmpi` might install in `/usr/include/hdf5/openmpi`, so you could extend `CPATH` and `LD_LIBRARY_PATH` appropriately: e.g.: `export CPATH=$CPATH:/usr/include/hdf5/openmpi` `export LIBRARY_PATH=$LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/hdf5/openmpi`
+
+  * Install JDQZPP
 
   * Install I-EMIC
     * Create build directory

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,18 +50,11 @@ list(APPEND library_directories ${MRILU_DIR}/lib/) # MRILU
 list(APPEND library_dependencies ${Trilinos_LIBRARIES})
 list(APPEND library_dependencies ${Trilinos_TPL_LIBRARIES})
 
-# Build JDQZPP external project
-include(BuildExternalProject)
-BuildExternalProject(
-  JDQZPP
-  GIT_REPOSITORY git://github.com/erik808/jdqzpp.git
-  CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF
-  )
-
-BuildExternalProject_find_package(JDQZPP)
-
-include_directories(${JDQZPP_INCLUDE_DIR})
-list(APPEND library_directories ${JDQZPP_LIBRARY_DIR})
+find_package(JDQZPP REQUIRED)
+if (JDQZPP_FOUND)
+  include_directories(${JDQZPP_INCLUDE_DIR})
+  list(APPEND library_directories ${JDQZPP_LIBRARY_DIR})
+endif ()
 
 link_directories(${library_directories})
 


### PR DESCRIPTION
I don't think building other packages during configure time is a good idea (except for gtest where it is the only way).