### PR TITLE
macOS compatibility fixes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.3)
-# Download BuildExternalProject Module
 
-# file(DOWNLOAD
-#   https://raw.githubusercontent.com/Sbte/BuildExternalProject/master/BuildExternalProject.cmake
-#   ${CMAKE_BINARY_DIR}/external/cmake/BuildExternalProject.cmake
-#   TIMEOUT 5)
+execute_process(COMMAND mkdir -p ${CMAKE_BINARY_DIR}/external/cmake/ TIMEOUT 5)
+execute_process(COMMAND wget -O ${CMAKE_BINARY_DIR}/external/cmake/BuildExternalProject.cmake https://raw.githubusercontent.com/Sbte/BuildExternalProject/master/BuildExternalProject.cmake TIMEOUT 5)
 
-execute_process(COMMAND mkdir -p ${CMAKE_BINARY_DIR}/external/cmake/ TIMEOUT 5) 
-
-execute_process(COMMAND wget -O ${CMAKE_BINARY_DIR}/external/cmake/BuildExternalProject.cmake https://raw.githubusercontent.com/Sbte/BuildExternalProject/master/BuildExternalProject.cmake TIMEOUT 5) 
+if (NOT EXISTS "${CMAKE_BINARY_DIR}/external/cmake/BuildExternalProject.cmake")
+  # Download BuildExternalProject Module
+  file(DOWNLOAD
+    https://raw.githubusercontent.com/Sbte/BuildExternalProject/master/BuildExternalProject.cmake
+    ${CMAKE_BINARY_DIR}/external/cmake/BuildExternalProject.cmake
+    TIMEOUT 5)
+endif ()
 
 set(CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}/external/cmake" PARENT_SCOPE)

--- a/mrilu/CMakeLists.txt
+++ b/mrilu/CMakeLists.txt
@@ -4,7 +4,7 @@ enable_language(Fortran)
 
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   set(CMAKE_Fortran_FLAGS
-    "-g -u -O3 -fPIC -ffree-line-length-none")
+    "-g -O3 -fPIC -ffree-line-length-none")
   set(MODFLAG "-J")
 elseif (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   set(CMAKE_Fortran_FLAGS
@@ -20,7 +20,7 @@ NUMBASE=${CMAKE_CURRENT_BINARY_DIR}/build
 SOURCEDIR=${CMAKE_CURRENT_BINARY_DIR}
 OSNAME=
 MAKE=make
-ARFLAGS=-crsvU
+ARFLAGS=-crsv
 LD=${CMAKE_Fortran_COMPILER}
 LDFLAGS=
 CC=${CMAKE_C_COMPILER}

--- a/mrilu/CMakeLists.txt
+++ b/mrilu/CMakeLists.txt
@@ -1,5 +1,11 @@
 file(COPY . DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/mrilu)
 
+find_package(X11 REQUIRED)
+get_filename_component(X11_LIB_DIR "${X11_X11_LIB}" DIRECTORY)
+
+message ("-- X11 include: " ${X11_INCLUDE_DIR})
+message ("-- X11 library: " ${X11_LIB_DIR})
+
 enable_language(Fortran)
 
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
@@ -25,7 +31,7 @@ LD=${CMAKE_Fortran_COMPILER}
 LDFLAGS=
 CC=${CMAKE_C_COMPILER}
 CFLAGS=-ansi
-CPPFLAGS=
+CPPFLAGS=-I${X11_INCLUDE_DIR}
 CXX=${CMAKE_CXX_COMPILER}
 MPI_CC=
 F77=${CMAKE_Fortran_COMPILER}
@@ -35,7 +41,7 @@ MPI_F77=
 F90=${CMAKE_Fortran_COMPILER}
 MPI_F90=
 MODFLAG=${MODFLAG}
-LIB_X11=/usr/lib/X11")
+LIB_X11=${X11_LIB_DIR}")
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/mrilu/makefile.inc "${MAKEFILE_INC_CONTENT}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ message("-- CMAKE_Fortran_COMPILER:    ${CMAKE_Fortran_COMPILER}")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU") #gfortran, gcc
   
   set (CMAKE_Fortran_FLAGS
-	"-g -u -O0 -Wall -ffixed-line-length-132 -fdefault-real-8 -fPIC -ffree-line-length-none")
+	"-g -O0 -Wall -ffixed-line-length-132 -fdefault-real-8 -fPIC -ffree-line-length-none")
   set (CMAKE_CXX_FLAGS "-g -std=c++1y -O0 -Wall -fPIC -Wno-deprecated-declarations -DDEBUGGING_NEW")
   set (COMP_IDENT GNU)
   


### PR DESCRIPTION
* Remove non-existent/unportable `ar` and `gfortran` flags.
* Use `find_package` to locate X11 headers on platforms where these are not under `/usr/include`
* Fallback to `file(DOWNLOAD` on platforms without wget.