### PR TITLE
Fix compilation with CMake < 3.12

### DIFF
--- a/src/mrilucpp/CMakeLists.txt
+++ b/src/mrilucpp/CMakeLists.txt
@@ -15,11 +15,8 @@ target_compile_definitions(ifpack_mrilu PUBLIC HAVE_IFPACK_MRILU)
 target_include_directories(ifpack_mrilu PUBLIC ${MRILUCPP_INCLUDE_DIRS})
 target_include_directories(mrilucpp PUBLIC ${MRILUCPP_INCLUDE_DIRS})
 
-# Work around lack of target_link_directories in CMake 3.12
+link_directories(${MRILU_DIR}/lib)
 list(APPEND FORTRAN_LIBS precon mtstor misc iosrc)
-list(TRANSFORM FORTRAN_LIBS PREPEND ${MRILU_DIR}/lib/lib)
-list(TRANSFORM FORTRAN_LIBS APPEND .a)
-
 target_link_libraries(mrilucpp PRIVATE ${FORTRAN_LIBS})
 
 target_link_libraries(ifpack_mrilu PRIVATE


### PR DESCRIPTION
It is even possible that before this, MRILU was never linked properly. I'm not sure.