### PR TITLE
Fix the usage of const in Model

### DIFF
--- a/src/atmosphere/AtmosLocal.C
+++ b/src/atmosphere/AtmosLocal.C
@@ -534,7 +534,7 @@ void AtmosLocal::setPdist(double *Pdist)
 }
 
 //-----------------------------------------------------------------------------
-void AtmosLocal::getCommPars(AtmosLocal::CommPars &parStruct)
+void AtmosLocal::getCommPars(AtmosLocal::CommPars &parStruct) const
 {
     parStruct.tdim = tdim_;
     parStruct.qdim = qdim_;

--- a/src/atmosphere/AtmosLocal.H
+++ b/src/atmosphere/AtmosLocal.H
@@ -380,7 +380,7 @@ public:
     void zeroState();
 
     //! Obtain parameters
-    void getCommPars(CommPars &parStruct);
+    void getCommPars(CommPars &parStruct) const;
 
     //! Get the dA_{ij} coefficients for surface integrals with q. We
     //! ignore land points by default. Also for the q integral.

--- a/src/atmosphere/Atmosphere.C
+++ b/src/atmosphere/Atmosphere.C
@@ -446,7 +446,7 @@ void Atmosphere::idealized(double precip)
 }
 
 //==================================================================
-Teuchos::RCP<Epetra_Vector> Atmosphere::interface(int XX)
+Teuchos::RCP<Epetra_Vector> Atmosphere::interface(int XX) const
 {
     if ( XX >= ATMOS_PP_ )
     {
@@ -461,33 +461,33 @@ Teuchos::RCP<Epetra_Vector> Atmosphere::interface(int XX)
     else
     {
         Teuchos::RCP<Epetra_Vector> out =
-            Teuchos::rcp(new Epetra_Vector(*Maps_[XX]));
+            Teuchos::rcp(new Epetra_Vector(*Maps_.at(XX)));
 
-        CHECK_ZERO(out->Import(*state_, *Imps_[XX], Insert));
+        CHECK_ZERO(out->Import(*state_, *Imps_.at(XX), Insert));
         return out;
     }
 }
 
 //==================================================================
-Teuchos::RCP<Epetra_Vector> Atmosphere::interfaceT()
+Teuchos::RCP<Epetra_Vector> Atmosphere::interfaceT() const
 {
     return interface(ATMOS_TT_);
 }
 
 //==================================================================
-Teuchos::RCP<Epetra_Vector> Atmosphere::interfaceQ()
+Teuchos::RCP<Epetra_Vector> Atmosphere::interfaceQ() const
 {
     return interface(ATMOS_QQ_);
 }
 
 //==================================================================
-Teuchos::RCP<Epetra_Vector> Atmosphere::interfaceA()
+Teuchos::RCP<Epetra_Vector> Atmosphere::interfaceA() const
 {
     return interface(ATMOS_AA_);
 }
 
 //==================================================================
-Teuchos::RCP<Epetra_Vector> Atmosphere::interfaceP()
+Teuchos::RCP<Epetra_Vector> Atmosphere::interfaceP() const
 {
     return interface(ATMOS_PP_);
 }
@@ -1397,7 +1397,7 @@ void Atmosphere::postProcess()
 }
 
 //==================================================================
-std::string const Atmosphere::writeData(bool describe)
+std::string Atmosphere::writeData(bool describe) const
 {
     std::ostringstream datastring;
 

--- a/src/atmosphere/Atmosphere.C
+++ b/src/atmosphere/Atmosphere.C
@@ -275,10 +275,10 @@ void Atmosphere::computeRHS()
                       // in serial AtmosLocal
     {
         // compute and obtain evaporation field
-        getE();
+        setE();
 
         // compute and obtain precipitation field
-        getP();
+        setP();
 
         // return precipitation field to local atmosphere
         CHECK_ZERO(localP_->Import(*P_, *as2std_surf_, Insert));
@@ -456,8 +456,7 @@ Teuchos::RCP<Epetra_Vector> Atmosphere::interface(int XX)
                     << "P is 'diagnosed'", __FILE__, __LINE__);
         }
 
-        getP();
-        return Utils::getVector('C', P_);
+        return getP();
     }
     else
     {
@@ -1152,12 +1151,21 @@ Teuchos::RCP<Epetra_Vector> Atmosphere::getE(char mode)
 }
 
 //==================================================================
-Teuchos::RCP<Epetra_Vector> Atmosphere::getP(char mode)
+void Atmosphere::setE()
 {
+    getE('V');
+}
+
+//==================================================================
+Teuchos::RCP<Epetra_Vector> Atmosphere::getP(Teuchos::RCP<Epetra_Vector> P) const
+{
+    if (P == Teuchos::null)
+        P = Utils::getVector('C', P_);
+
     // P is a single, globally computed unknown
     double Pvalue = 0.0;
-    int numGlobalElements = P_->Map().NumGlobalElements();
-    int numMyElements     = P_->Map().NumMyElements();
+    int numGlobalElements = P->Map().NumGlobalElements();
+    int numMyElements     = P->Map().NumMyElements();
     assert((int) surfmask_->size() == numGlobalElements);
 
     Atmosphere::CommPars pars;
@@ -1206,14 +1214,20 @@ Teuchos::RCP<Epetra_Vector> Atmosphere::getP(char mode)
     int gid;
     for (int i = 0; i != numMyElements; ++i)
     {
-        gid = P_->Map().GID(i);
+        gid = P->Map().GID(i);
         if ((*surfmask_)[gid] == 0)
-            (*P_)[i] = (*Pdist_)[i] *
+            (*P)[i] = (*Pdist_)[i] *
                 (pars.Eo0 + pars.eta * pars.qdim * Pvalue);
         else
-            (*P_)[i] = 0.0;
+            (*P)[i] = 0.0;
     }
-    return Utils::getVector(mode, P_);
+    return P;
+}
+
+//==================================================================
+void Atmosphere::setP()
+{
+    getP(P_);
 }
 
 //==================================================================
@@ -1351,7 +1365,7 @@ void Atmosphere::buildPreconditioner()
 }
 
 //==================================================================
-void Atmosphere::getCommPars(Atmosphere::CommPars &parStruct)
+void Atmosphere::getCommPars(Atmosphere::CommPars &parStruct) const
 {
     atmos_->getCommPars(parStruct);
 }

--- a/src/atmosphere/Atmosphere.H
+++ b/src/atmosphere/Atmosphere.H
@@ -195,8 +195,8 @@ public:
 
     ~Atmosphere() {INFO("Atmosphere destructor");}
     
-    std::string const name() { return "atmos"; }
-    virtual int const modelIdent() { return 1; }
+    std::string name() const { return "atmos"; }
+    virtual int modelIdent() const { return 1; }
     
     //! Setup integral coefficients
     void setupIntCoeff();
@@ -264,7 +264,7 @@ public:
     void postProcess();
 
     //! Gather important continuation data to use in summary
-    std::string const writeData(bool describe = false); 
+    std::string writeData(bool describe = false) const; 
 
     void printState(std::string const &fname);
 
@@ -282,7 +282,7 @@ public:
     int npar() { return atmos_->npar(); }
 
     //! Return parameter name, supply index
-    std::string const int2par(int ind) { return atmos_->int2par(ind); }
+    std::string int2par(int ind) const { return atmos_->int2par(ind); }
 
     Teuchos::RCP<Epetra_Vector> getState(char mode = 'C')
         { return Utils::getVector(mode, state_); }
@@ -299,19 +299,19 @@ public:
     Teuchos::RCP<TRIOS::Domain> getDomain() { return domain_; }
 
     //! Factorized interface routine
-    Teuchos::RCP<Epetra_Vector> interface(int XX);
+    Teuchos::RCP<Epetra_Vector> interface(int XX) const;
     
     //! Get temperature at interface 
-    Teuchos::RCP<Epetra_Vector> interfaceT();
+    Teuchos::RCP<Epetra_Vector> interfaceT() const;
 
     //! Get humidity at interface 
-    Teuchos::RCP<Epetra_Vector> interfaceQ();
+    Teuchos::RCP<Epetra_Vector> interfaceQ() const;
 
     //! Get albedo at interface 
-    Teuchos::RCP<Epetra_Vector> interfaceA();
+    Teuchos::RCP<Epetra_Vector> interfaceA() const;
 
     //! Get precipitation at interface 
-    Teuchos::RCP<Epetra_Vector> interfaceP();
+    Teuchos::RCP<Epetra_Vector> interfaceP() const;
 
     //! Compute evaporation at interface
     Teuchos::RCP<Epetra_Vector> interfaceE();

--- a/src/atmosphere/Atmosphere.H
+++ b/src/atmosphere/Atmosphere.H
@@ -258,7 +258,7 @@ public:
     double getPar(std::string const &parName) { return atmos_->getPar(parName); }
 
     //! Get parameters that we want to communicate
-    void getCommPars(CommPars &parStruct);
+    void getCommPars(CommPars &parStruct) const;
 
     void preProcess();
     void postProcess();
@@ -350,13 +350,19 @@ private:
 
     //! set precipitation distribution
     void setPdist();
-        
+
     //! Private member to compute P if it is not an unknown in the
     //! model.
-    Teuchos::RCP<Epetra_Vector> getP(char mode = 'C');
+    Teuchos::RCP<Epetra_Vector> getP(Teuchos::RCP<Epetra_Vector> P = Teuchos::null) const;
+
+    //! Private member to compute P_.
+    void setP();
 
     //! Private member to compute E
     Teuchos::RCP<Epetra_Vector> getE(char mode = 'C');
+
+    //! Private member to compute E_.
+    void setE();
 
     //! create dependency graph for the Jacobian matrix
     //! function borrowed from THCM,

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -829,7 +829,7 @@ void Ocean::postProcess()
 }
 
 //=====================================================================
-std::string const Ocean::writeData(bool describe)
+std::string Ocean::writeData(bool describe) const
 {
     std::ostringstream datastring;
     if (describe)
@@ -871,7 +871,7 @@ std::string const Ocean::writeData(bool describe)
     }
 }
 
-int Ocean::getPsiM(double &psiMin, double &psiMax)
+int Ocean::getPsiM(double &psiMin, double &psiMax) const
 {
     grid_->ImportData(*state_);
     psiMax = grid_->psimMax();
@@ -2206,7 +2206,7 @@ double Ocean::getPar(std::string const &parName)
 int Ocean::npar() { return _NPAR_; }
 
 //===================================================================
-std::string const Ocean::int2par(int ind)
+std::string Ocean::int2par(int ind) const
 {
     return THCM::Instance().int2par(ind+1);
 }

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -91,7 +91,7 @@ protected:
     VectorPtr sol_;
 
     // grid representation of the state
-    Teuchos::RCP<OceanGrid> grid_;
+    mutable Teuchos::RCP<OceanGrid> grid_;
 
     ParameterList solverParams_;
 
@@ -103,7 +103,7 @@ protected:
                  <double, Epetra_MultiVector, Epetra_Operator> > belosSolver_;
 
     double effort_;
-    int effortCtr_;
+    mutable int effortCtr_;
 
     Teuchos::RCP<Ifpack_Preconditioner> precPtr_;
 
@@ -164,8 +164,8 @@ public:
     //! destructor
     ~Ocean();
 
-    std::string const name() { return "ocean"; }
-    int const modelIdent() { return 0; }
+    std::string name() const { return "ocean"; }
+    int modelIdent() const { return 0; }
     Teuchos::RCP<Epetra_Comm> Comm() const { return comm_; }
 
     //! Solve may optionally accept an rhs of VectorPointer type
@@ -243,7 +243,7 @@ public:
     int npar();
 
     //! Convert integer parameter index to parameter name
-    std::string const int2par(int ind);
+    std::string int2par(int ind) const;
 
     //! Get current landmask
     Utils::MaskStruct getLandMask()
@@ -287,7 +287,7 @@ public:
     void postProcess();
 
     //! Gather important data to use in continuation summary
-    std::string const writeData(bool describe = false);
+    std::string writeData(bool describe = false) const;
 
     //! Get functions for the grid dimensions
     int getNdim() { return N_;}
@@ -295,7 +295,7 @@ public:
     int getLdim() { return L_;}
 
     //! Get the minimum and maximum of the Meridional streamfunction
-    int getPsiM(double &psiMin, double &psiMax);
+    int getPsiM(double &psiMin, double &psiMax) const;
 
     //! Get coupling information
     int getCoupledT();

--- a/src/seaice/SeaIce.C
+++ b/src/seaice/SeaIce.C
@@ -827,7 +827,7 @@ int SeaIce::npar()
 }
 
 //-----------------------------------------------------------------------------
-std::string const SeaIce::int2par(int ind)
+std::string SeaIce::int2par(int ind) const
 {
     return allParameters_[ind];
 }
@@ -1169,10 +1169,10 @@ void SeaIce::synchronize(std::shared_ptr<Atmosphere> atmos)
 }
 
 //=============================================================================
-Teuchos::RCP<Epetra_Vector> SeaIce::interface(Teuchos::RCP<Epetra_Vector> vec, int XX)
+Teuchos::RCP<Epetra_Vector> SeaIce::interface(Teuchos::RCP<Epetra_Vector> vec, int XX) const
 {
-    Teuchos::RCP<Epetra_Vector> out = Teuchos::rcp(new Epetra_Vector(*Maps_[XX]));
-    CHECK_ZERO(out->Import(*vec, *Imps_[XX], Insert));
+    Teuchos::RCP<Epetra_Vector> out = Teuchos::rcp(new Epetra_Vector(*Maps_.at(XX)));
+    CHECK_ZERO(out->Import(*vec, *Imps_.at(XX), Insert));
 
     assert(out->MyLength() >= 1);
 
@@ -1189,31 +1189,31 @@ Teuchos::RCP<Epetra_Vector> SeaIce::interface(Teuchos::RCP<Epetra_Vector> vec, i
 }
 
 //=============================================================================
-Teuchos::RCP<Epetra_Vector> SeaIce::interfaceH()
+Teuchos::RCP<Epetra_Vector> SeaIce::interfaceH() const
 {
     return interface(state_, SEAICE_HH_);
 }
 
 //=============================================================================
-Teuchos::RCP<Epetra_Vector> SeaIce::interfaceQ()
+Teuchos::RCP<Epetra_Vector> SeaIce::interfaceQ() const
 {
     return interface(state_, SEAICE_QQ_);
 }
 
 //=============================================================================
-Teuchos::RCP<Epetra_Vector> SeaIce::interfaceM()
+Teuchos::RCP<Epetra_Vector> SeaIce::interfaceM() const
 {
     return interface(state_, SEAICE_MM_);
 }
 
 //=============================================================================
-Teuchos::RCP<Epetra_Vector> SeaIce::interfaceT()
+Teuchos::RCP<Epetra_Vector> SeaIce::interfaceT() const
 {
     return interface(state_, SEAICE_TT_);
 }
 
 //=============================================================================
-Teuchos::RCP<Epetra_Vector> SeaIce::interfaceG()
+Teuchos::RCP<Epetra_Vector> SeaIce::interfaceG() const
 {
     if (aux_ == 1)
         return interface(state_, SEAICE_GG_);
@@ -1551,7 +1551,7 @@ void SeaIce::postProcess()
 }
 
 //=============================================================================
-std::string const SeaIce::writeData(bool describe)
+std::string SeaIce::writeData(bool describe) const
 {
     std::ostringstream datastring;
 

--- a/src/seaice/SeaIce.H
+++ b/src/seaice/SeaIce.H
@@ -326,8 +326,8 @@ public:
     //! destructor
     ~SeaIce() {};
 
-    std::string const name() { return "seaice"; }
-    virtual int const modelIdent() { return 2; }
+    std::string name() const { return "seaice"; }
+    virtual int modelIdent() const { return 2; }
 
     //! compute QSos and EmiP fluxes locally
     void computeLocalFluxes(double *state, double *sss, double *sst,
@@ -386,7 +386,7 @@ public:
     int npar();
 
     //! convert index to parameter name
-    std::string const int2par(int ind);
+    std::string int2par(int ind) const;
 
     Utils::MaskStruct getLandMask()
         {
@@ -410,13 +410,13 @@ public:
 
     void pressureProjection(Teuchos::RCP<Epetra_Vector> vec) {}
 
-    Teuchos::RCP<Epetra_Vector> interface(Teuchos::RCP<Epetra_Vector> vec, int XX);
+    Teuchos::RCP<Epetra_Vector> interface(Teuchos::RCP<Epetra_Vector> vec, int XX) const;
 
-    Teuchos::RCP<Epetra_Vector> interfaceH();
-    Teuchos::RCP<Epetra_Vector> interfaceQ();
-    Teuchos::RCP<Epetra_Vector> interfaceM();
-    Teuchos::RCP<Epetra_Vector> interfaceT();
-    Teuchos::RCP<Epetra_Vector> interfaceG();
+    Teuchos::RCP<Epetra_Vector> interfaceH() const;
+    Teuchos::RCP<Epetra_Vector> interfaceQ() const;
+    Teuchos::RCP<Epetra_Vector> interfaceM() const;
+    Teuchos::RCP<Epetra_Vector> interfaceT() const;
+    Teuchos::RCP<Epetra_Vector> interfaceG() const;
 
     // global interface row
     int interface_row(int i, int j, int XX)
@@ -431,7 +431,7 @@ public:
     void preProcess();
     void postProcess();
 
-    std::string const writeData(bool describe);
+    std::string writeData(bool describe) const;
 
 private:
     //! create x_ and y_

--- a/src/utils/Model.H
+++ b/src/utils/Model.H
@@ -75,13 +75,13 @@ public:
     virtual int npar() = 0;
 
     //! Convert integer parameter index to parameter name
-    virtual std::string const int2par(int ind) = 0;
+    virtual std::string int2par(int ind) const = 0;
 
     virtual Utils::MaskStruct getLandMask() = 0;
     virtual void setLandMask(Utils::MaskStruct const &mask) = 0;
 
-    virtual std::string const name() = 0;
-    virtual int const modelIdent() = 0;
+    virtual std::string name() const = 0;
+    virtual int modelIdent() const = 0;
 
     virtual Teuchos::RCP<TRIOS::Domain> getDomain() = 0;
 
@@ -115,7 +115,7 @@ public:
     virtual void postProcess() = 0;
 
     //! Plaintext data output
-    virtual std::string const writeData(bool describe) = 0;
+    virtual std::string writeData(bool describe) const = 0;
 
     //! HDF5-based load function for the state and parameters
     int loadStateFromFile(std::string const &filename);


### PR DESCRIPTION
The Intel compiler complained about the usage of const in Model. I instead turned all methods that it complained about into const methods.  I also noticed that getP always copied a vector to the output, even if it was called as `getP()`. So this should actually be faster.