### PR TITLE
Properly store the weights array and iterations in (T)AMS

### DIFF
--- a/src/main/run_coupled.C
+++ b/src/main/run_coupled.C
@@ -133,7 +133,7 @@ void runCoupledModel(RCP<Epetra_Comm> Comm)
 
     // Run continuation
     int status = continuation.run();
-    if (status == 0)
+    if (status != 0)
         ERROR("Continuation failed", __FILE__, __LINE__);
 
     TIMER_STOP("Total time...");

--- a/src/main/run_ocean.C
+++ b/src/main/run_ocean.C
@@ -99,7 +99,7 @@ void runOceanModel(RCP<Epetra_Comm> Comm)
 
     // Run continuation
     int status = continuation.run();
-    if (status == 0)
+    if (status != 0)
         ERROR("Continuation failed", __FILE__, __LINE__);
 
     TIMER_STOP("Total time...");

--- a/src/main/time_coupled.C
+++ b/src/main/time_coupled.C
@@ -131,7 +131,7 @@ void runCoupledModel(RCP<Epetra_Comm> Comm)
 
     // run timestepper
     int status = stepper->run();
-    if (status == 0)
+    if (status != 0)
         ERROR("Timestepper failed", __FILE__, __LINE__);
 
     TIMER_STOP("Total time...");

--- a/src/main/time_ocean.C
+++ b/src/main/time_ocean.C
@@ -74,7 +74,7 @@ void runOceanModel(RCP<Epetra_Comm> Comm)
 
     // Run time stepper
     int status = stepper->run();
-    if (status == 0)
+    if (status != 0)
         ERROR("Timestepper failed", __FILE__, __LINE__);
 
     TIMER_STOP("Total time...");

--- a/src/seaice/SeaIce.C
+++ b/src/seaice/SeaIce.C
@@ -419,6 +419,9 @@ void SeaIce::computeRHS()
 
                     val = Tsi - Tval;
                     break;
+                default:
+                    ERROR("SeaIce: Invalid unknown " << XX, __FILE__, __LINE__);
+                    return;
                 }
 
                 rr = find_row0(nLoc_, mLoc_, i, j, XX);

--- a/src/tests/test_ams.C
+++ b/src/tests/test_ams.C
@@ -260,7 +260,7 @@ void restart_test(Teuchos::RCP<Teuchos::ParameterList> params)
     if (ams2->get_mfpt() > 0)
     {
         EXPECT_GT(ams2->get_mfpt(), 6);
-        EXPECT_LT(ams2->get_mfpt(), 10);
+        EXPECT_LT(ams2->get_mfpt(), 20);
     }
     else
         EXPECT_NEAR(ams2->get_probability(), 0.157, 5e-1);
@@ -318,7 +318,7 @@ TEST(AMS, AMSRestart5)
     Teuchos::RCP<Teuchos::ParameterList> params = rcp(new Teuchos::ParameterList);
     params->set("method", "AMS");
     params->set("write final state", true);
-    params->set("maximum iterations", 40);
+    params->set("maximum iterations", 30);
 
     restart_test(params);
 }
@@ -413,7 +413,7 @@ TEST(AMS, TAMSRestart5)
     Teuchos::RCP<Teuchos::ParameterList> params = rcp(new Teuchos::ParameterList);
     params->set("method", "TAMS");
     params->set("write final state", true);
-    params->set("maximum iterations", 40);
+    params->set("maximum iterations", 30);
 
     restart_test(params);
 }

--- a/src/tests/test_ams.C
+++ b/src/tests/test_ams.C
@@ -221,6 +221,8 @@ void restart_test(Teuchos::RCP<Teuchos::ParameterList> params)
 
     std::string output2 = out_stream->str();
 
+    // std::cout << output2;
+
     EXPECT_EQ(output2.find("Initialization"), std::string::npos);
     EXPECT_EQ(output2.find("AMS: " + std::to_string(default_maxit + 1)),
               std::string::npos);
@@ -250,18 +252,18 @@ void restart_test(Teuchos::RCP<Teuchos::ParameterList> params)
         EXPECT_NE(output2.find("AMS: " + std::to_string(default_maxit)),
                   std::string::npos);
     }
-    EXPECT_NE(output2.find("AMS: " + std::to_string(default_maxit + 1)),
+    EXPECT_NE(output2.find("AMS: " + std::to_string(maxit + 1)),
               std::string::npos);
     EXPECT_EQ(output2.find("AMS: " + std::to_string(default_maxit * 8)),
               std::string::npos);
 
     if (ams2->get_mfpt() > 0)
     {
-        EXPECT_GT(ams2->get_mfpt(), 5);
-        EXPECT_LT(ams2->get_mfpt(), 40);
+        EXPECT_GT(ams2->get_mfpt(), 6);
+        EXPECT_LT(ams2->get_mfpt(), 10);
     }
     else
-        EXPECT_NEAR(ams2->get_probability(), 0.157, 1e-1);
+        EXPECT_NEAR(ams2->get_probability(), 0.157, 5e-1);
 }
 
 #if TRILINOS_MAJOR_MINOR_VERSION > 121300
@@ -306,6 +308,17 @@ TEST(AMS, AMSRestart4)
     params->set("write steps", 10);
     params->set("maximum iterations", 0);
     params->set("write final state", false);
+
+    restart_test(params);
+}
+
+//------------------------------------------------------------------
+TEST(AMS, AMSRestart5)
+{
+    Teuchos::RCP<Teuchos::ParameterList> params = rcp(new Teuchos::ParameterList);
+    params->set("method", "AMS");
+    params->set("write final state", true);
+    params->set("maximum iterations", 40);
 
     restart_test(params);
 }
@@ -390,6 +403,17 @@ TEST(AMS, TAMSRestart4)
     params->set("write steps", 10);
     params->set("maximum iterations", 0);
     params->set("write final state", false);
+
+    restart_test(params);
+}
+
+//------------------------------------------------------------------
+TEST(AMS, TAMSRestart5)
+{
+    Teuchos::RCP<Teuchos::ParameterList> params = rcp(new Teuchos::ParameterList);
+    params->set("method", "TAMS");
+    params->set("write final state", true);
+    params->set("maximum iterations", 40);
 
     restart_test(params);
 }

--- a/src/transient/Transient.cpp
+++ b/src/transient/Transient.cpp
@@ -73,6 +73,14 @@ void Transient<Teuchos::RCP<const Epetra_Vector> >::read(
 
     HDF5.Read("data", "its", its_);
 
+    int ell_size = -1;
+    HDF5.Read("data", "ell size", ell_size);
+    if (ell_size > 0)
+    {
+       ell_.resize(ell_size);
+       HDF5.Read("data", "ell", H5T_NATIVE_INT, ell_size, &ell_[0]);
+    }
+
     Teuchos::RCP<Epetra_Import> import = Teuchos::null;
     Epetra_MultiVector *tmp;
     Epetra_BlockMap const &map = experiments[0].x0->Map();
@@ -195,6 +203,11 @@ void Transient<Teuchos::RCP<const Epetra_Vector> >::write(
     HDF5.Write("data", "its", its_);
     HDF5.Write("data", "num exp", num_exp_);
     HDF5.Write("data", "num init exp", num_init_exp_);
+
+    int ell_size = ell_.size();
+    HDF5.Write("data", "ell size", ell_size);
+    if (ell_size > 0)
+        HDF5.Write("data", "ell", H5T_NATIVE_INT, ell_.size(), &ell_[0]);
 
     if (lock_file >= 0)
         close(lock_file);

--- a/src/transient/Transient.hpp
+++ b/src/transient/Transient.hpp
@@ -353,7 +353,6 @@ double Transient<T>::ams_elimination(
 {
     int converged = 0;
 
-    std::vector<int> ell;
     std::vector<AMSExperiment<T> *> reactive_experiments;
     std::vector<AMSExperiment<T> *> unconverged_experiments;
     std::vector<AMSExperiment<T> *> unused_experiments;
@@ -397,14 +396,14 @@ double Transient<T>::ams_elimination(
         if (minimal_experiments.size() == 0 || unused_experiments.size() == 0)
             continue;
 
-        ell.push_back(minimal_experiments.size());
-        if (ell.back() == 1)
+        ell_.push_back(minimal_experiments.size());
+        if (ell_.back() == 1)
         {
             INFO("Eliminating 1 trajectory.");
         }
         else
         {
-            INFO("Eliminating " << ell.back() << " trajectories.");
+            INFO("Eliminating " << ell_.back() << " trajectories.");
         }
 
         its_++;
@@ -510,7 +509,7 @@ double Transient<T>::ams_elimination(
         write(write_, experiments);
 
     double alpha = (double)converged / (double)num_exp_;
-    for (int l: ell)
+    for (int l: ell_)
         alpha *= 1.0 - (double)l / (double)num_exp_;
 
     return alpha;
@@ -529,6 +528,7 @@ void Transient<T>::ams(T const &x0) const
 
     its_ = 0;
     time_steps_ = 0;
+    ell_.clear();
 
     if (read_ != "")
         read(read_, experiments);
@@ -617,6 +617,7 @@ void Transient<T>::tams(T const &x0) const
 
     its_ = 0;
     time_steps_ = 0;
+    ell_.clear();
 
     if (read_ != "")
         read(read_, experiments);

--- a/src/transient/Transient.hpp
+++ b/src/transient/Transient.hpp
@@ -374,7 +374,7 @@ double Transient<T>::ams_elimination(
     std::sort(unconverged_experiments.begin(),
               unconverged_experiments.end(), AMSExperiment<T>::sort);
 
-    for (int i = 0; i < maxit_; i++)
+    for (int i = its_; i < maxit_; i++)
     {
         minimal_experiments.clear();
         if (unconverged_experiments.size() > 0 && unused_experiments.size() > 0)

--- a/src/transient/TransientDecl.hpp
+++ b/src/transient/TransientDecl.hpp
@@ -44,6 +44,8 @@ protected:
     mutable int time_steps_;
     mutable int time_steps_previous_write_;
 
+    mutable std::vector<int> ell_;
+
     std::string read_;
     std::string write_;
     bool write_final_;


### PR DESCRIPTION
This bug also caused some of the test failures on macOS that we had earlier, so I reduced the test tolerance a bit.