### PR TITLE
Generate info for clang tooling and silence warnings from Trilinos.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ else ()
 endif ()
 project(i-emic)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(DATA_DIR "'${CMAKE_CURRENT_SOURCE_DIR}/data/'")
 message("-- Data is stored in: " ${DATA_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (APPLE)
     cmake_minimum_required(VERSION 3.13)
 else ()
-    cmake_minimum_required(VERSION 3.3)
+    cmake_minimum_required(VERSION 3.5)
 endif ()
 project(i-emic)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,8 +32,8 @@ elseif (CMAKE_Fortran_COMPILER_ID MATCHES "Intel") #ifort, icc
   
 endif ()
 
-include_directories(${Trilinos_INCLUDE_DIRS})
-include_directories(${Trilinos_TPL_INCLUDE_DIRS})
+include_directories(SYSTEM ${Trilinos_INCLUDE_DIRS})
+include_directories(SYSTEM ${Trilinos_TPL_INCLUDE_DIRS})
 
 set(library_directories ${Trilinos_LIBRARY_DIRS})
 list(APPEND library_directories ${Trilinos_TPL_LIBRARY_DIRS})


### PR DESCRIPTION
Set CMake to automatically generate compile_commands.json for clang tooling.
Switch to using SYSTEM includes to silence warnings coming from Trilinos header
files.