### PR TITLE
Centralise Ocean parameters

### DIFF
--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -52,38 +52,42 @@ extern "C" _SUBROUTINE_(set_seaice_parameters)(SeaIce::CommPars*);
 
 //=====================================================================
 // Constructor:
-Ocean::Ocean(RCP<Epetra_Comm> Comm, ParameterList oceanParamList)
+Ocean::Ocean(RCP<Epetra_Comm> Comm, Model::ParameterList paramListPtr)
+    : Ocean(Comm, *paramListPtr)
+{}
+
+Ocean::Ocean(RCP<Epetra_Comm> Comm, Teuchos::ParameterList& oceanParamList)
     :
     solverInitialized_     (false),  // Solver needs initialization
     precInitialized_       (false),  // Preconditioner needs initialization
     recompPreconditioner_  (true),   // We need a preconditioner to start with
     recompMassMat_         (true),   // We need a mass matrix to start with
 
-    loadSalinityFlux_      (oceanParamList->get("Load salinity flux", false)),
-    saveSalinityFlux_      (oceanParamList->get("Save salinity flux", true)),
-    loadTemperatureFlux_   (oceanParamList->get("Load temperature flux", false)),
-    saveTemperatureFlux_   (oceanParamList->get("Save temperature flux", true)),
+    loadSalinityFlux_      (oceanParamList.get("Load salinity flux", false)),
+    saveSalinityFlux_      (oceanParamList.get("Save salinity flux", true)),
+    loadTemperatureFlux_   (oceanParamList.get("Load temperature flux", false)),
+    saveTemperatureFlux_   (oceanParamList.get("Save temperature flux", true)),
 
-    useFort3_              (oceanParamList->get("Use legacy fort.3 output", false)),
-    useFort44_             (oceanParamList->get("Use legacy fort.44 output", true)),
-    saveColumnIntegral_    (oceanParamList->get("Save column integral", false)),
-    maxMaskFixes_          (oceanParamList->get("Max mask fixes", 5)),
+    useFort3_              (oceanParamList.get("Use legacy fort.3 output", false)),
+    useFort44_             (oceanParamList.get("Use legacy fort.44 output", true)),
+    saveColumnIntegral_    (oceanParamList.get("Save column integral", false)),
+    maxMaskFixes_          (oceanParamList.get("Max mask fixes", 5)),
 
-    landmaskFile_          (oceanParamList->sublist("THCM").get("Land Mask", "none")),
+    landmaskFile_          (oceanParamList.sublist("THCM").get("Land Mask", "none")),
 
-    analyzeJacobian_       (oceanParamList->get("Analyze Jacobian", true))
+    analyzeJacobian_       (oceanParamList.get("Analyze Jacobian", true))
 {
     INFO("Ocean: constructor...");
 
     // inherited input/output datamembers
-    inputFile_   = oceanParamList->get("Input file",  "ocean_input.h5");
-    outputFile_  = oceanParamList->get("Output file", "ocean_output.h5");
-    saveMask_    = oceanParamList->get("Save mask", true);
-    loadMask_    = oceanParamList->get("Load mask", true);
+    inputFile_   = oceanParamList.get("Input file",  "ocean_input.h5");
+    outputFile_  = oceanParamList.get("Output file", "ocean_output.h5");
+    saveMask_    = oceanParamList.get("Save mask", true);
+    loadMask_    = oceanParamList.get("Load mask", true);
 
-    loadState_   = oceanParamList->get("Load state", false);
-    saveState_   = oceanParamList->get("Save state", true);
-    saveEvery_   = oceanParamList->get("Save frequency", 0);
+    loadState_   = oceanParamList.get("Load state", false);
+    saveState_   = oceanParamList.get("Save state", true);
+    saveEvery_   = oceanParamList.get("Save frequency", 0);
 
     // initialize postprocessing counter
     ppCtr_ = 0;
@@ -96,7 +100,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, ParameterList oceanParamList)
     //  instance at a time. The Ocean class can access THCM with a call
     //  to THCM::Instance()
     const Teuchos::ParameterList &thcmList =
-        oceanParamList->sublist("THCM");
+        oceanParamList.sublist("THCM");
 
     thcm_ = rcp(new THCM(thcmList, comm_));
 
@@ -202,7 +206,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, ParameterList oceanParamList)
     surfaceSimporter_ =
         Teuchos::rcp(new Epetra_Import(*sIndexMap_, state_->Map()));
 
-    INFO(*oceanParamList);
+    INFO(oceanParamList);
     INFO("\n");
     INFO("Ocean couplings: coupled_T = " << getCoupledT() );
     INFO("                 coupled_S = " << getCoupledS() );

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -2243,7 +2243,7 @@ Ocean::getDefaultParameters()
     return result;
 }
 
-const Teuchos::ParameterList&  Ocean::getParameters()
+const Teuchos::ParameterList& Ocean::getParameters()
 { return params_; }
 
 void Ocean::setOceanParameters()
@@ -2274,12 +2274,14 @@ void Ocean::setOceanParameters()
 void Ocean::setInitParameters(Teuchos::ParameterList newParams)
 {
     setDefaultInitParameters(newParams);
+    newParams.validateParameters(getDefaultInitParameters());
     params_ = newParams;
     setOceanParameters();
 }
 
 void Ocean::setParameters(Teuchos::ParameterList newParams)
 {
+    newParams.validateParameters(getDefaultParameters());
     params_.setParameters(newParams);
     setOceanParameters();
 }

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -966,30 +966,30 @@ void Ocean::initializeBelos()
     int maxiters          = NumGlobalElements/blocksize - 1;
 
     // Create Belos parameterlist
-    RCP<Teuchos::ParameterList> belosParamList_ = rcp(new Teuchos::ParameterList());
-    belosParamList_->set("Block Size", blocksize);
-    belosParamList_->set("Flexible Gmres", true);
-    belosParamList_->set("Adaptive Block Size", true);
-    belosParamList_->set("Num Blocks", gmresIters);
-    belosParamList_->set("Maximum Restarts", maxrestarts);
-    belosParamList_->set("Orthogonalization","DGKS");
-    belosParamList_->set("Output Frequency", output);
-    belosParamList_->set("Verbosity", Belos::Errors + Belos::Warnings);
-    belosParamList_->set("Maximum Iterations", maxiters);
-    belosParamList_->set("Convergence Tolerance", gmresTol);
-    belosParamList_->set("Explicit Residual Test", testExpl);
-    belosParamList_->set("Implicit Residual Scaling",
+    RCP<Teuchos::ParameterList> belosParamList = rcp(new Teuchos::ParameterList());
+    belosParamList->set("Block Size", blocksize);
+    belosParamList->set("Flexible Gmres", true);
+    belosParamList->set("Adaptive Block Size", true);
+    belosParamList->set("Num Blocks", gmresIters);
+    belosParamList->set("Maximum Restarts", maxrestarts);
+    belosParamList->set("Orthogonalization","DGKS");
+    belosParamList->set("Output Frequency", output);
+    belosParamList->set("Verbosity", Belos::Errors + Belos::Warnings);
+    belosParamList->set("Maximum Iterations", maxiters);
+    belosParamList->set("Convergence Tolerance", gmresTol);
+    belosParamList->set("Explicit Residual Test", testExpl);
+    belosParamList->set("Implicit Residual Scaling",
                          "Norm of Preconditioned Initial Residual");
 
-    // belosParamList_->set("Implicit Residual Scaling", "Norm of RHS");
-    // belosParamList_->set("Implicit Residual Scaling", "Norm of Initial Residual");
-    // belosParamList_->set("Explicit Residual Scaling", "Norm of RHS");
+    // belosParamList->set("Implicit Residual Scaling", "Norm of RHS");
+    // belosParamList->set("Implicit Residual Scaling", "Norm of Initial Residual");
+    // belosParamList->set("Explicit Residual Scaling", "Norm of RHS");
 
     // Belos block FGMRES setup
     belosSolver_ =
         rcp(new Belos::BlockGmresSolMgr
             <double, Epetra_MultiVector, Epetra_Operator>
-            (problem_, belosParamList_));
+            (problem_, belosParamList));
 
     // initialize effort counter
     effortCtr_ = 0;

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -179,7 +179,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, Teuchos::RCP<Teuchos::ParameterList> oceanPa
     surfaceSimporter_ =
         Teuchos::rcp(new Epetra_Import(*sIndexMap_, state_->Map()));
 
-    INFO(oceanParamList);
+    INFO(*oceanParamList);
     INFO("\n");
     INFO("Ocean couplings: coupled_T = " << getCoupledT() );
     INFO("                 coupled_S = " << getCoupledS() );

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -62,7 +62,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, Teuchos::RCP<Teuchos::ParameterList> oceanPa
 
 Ocean::Ocean(RCP<Epetra_Comm> Comm, Teuchos::ParameterList& oceanParamList)
     :
-    params_                (Teuchos::rcp(new Teuchos::ParameterList)),
+    params_                (Teuchos::rcp(new Teuchos::ParameterList("Ocean Configuration"))),
     solverInitialized_     (false),  // Solver needs initialization
     precInitialized_       (false),  // Preconditioner needs initialization
     recompPreconditioner_  (true),   // We need a preconditioner to start with
@@ -965,7 +965,7 @@ void Ocean::initializeBelos()
     int maxiters          = NumGlobalElements/blocksize - 1;
 
     // Create Belos parameterlist
-    RCP<Teuchos::ParameterList> belosParamList = rcp(new Teuchos::ParameterList());
+    RCP<Teuchos::ParameterList> belosParamList = rcp(new Teuchos::ParameterList("Belos List"));
     belosParamList->set("Block Size", blocksize);
     belosParamList->set("Flexible Gmres", true);
     belosParamList->set("Adaptive Block Size", true);
@@ -2183,6 +2183,7 @@ Teuchos::ParameterList
 Ocean::getDefaultInitParameters()
 {
     Teuchos::ParameterList result = getDefaultParameters();
+    result.setName("Default Init Ocean List");
     result.sublist("THCM") = THCM::getDefaultInitParameters();
     return result;
 }
@@ -2190,7 +2191,7 @@ Ocean::getDefaultInitParameters()
 Teuchos::ParameterList
 Ocean::getDefaultParameters()
 {
-    Teuchos::ParameterList result;
+    Teuchos::ParameterList result("Default Ocean List");
     result.get("Load salinity flux", false);
     result.get("Save salinity flux", true);
     result.get("Load temperature flux", false);
@@ -2234,6 +2235,7 @@ const Teuchos::ParameterList& Ocean::getParameters()
 void Ocean::setParameters(Teuchos::ParameterList& newParams)
 {
     Teuchos::ParameterList tmpParams(*params_);
+    tmpParams.setName("Temp parameter list");
     tmpParams.setParameters(newParams);
     thcm_->setParameters(newParams.sublist("THCM"));
     tmpParams.validateParametersAndSetDefaults(getDefaultInitParameters());

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -62,7 +62,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, Model::ParameterList paramListPtr)
 
 Ocean::Ocean(RCP<Epetra_Comm> Comm, const Teuchos::ParameterList& oceanParamList)
     :
-    params(defaultParameters()),
+    params_(defaultParameters()),
     solverInitialized_     (false),  // Solver needs initialization
     precInitialized_       (false),  // Preconditioner needs initialization
     recompPreconditioner_  (true),   // We need a preconditioner to start with
@@ -2222,34 +2222,34 @@ Ocean::defaultParameters()
 { return Ocean::defaultParams; }
 
 const Teuchos::ParameterList&  Ocean::getParameters()
-{ return params; }
+{ return params_; }
 
 void Ocean::setParameters(const Teuchos::ParameterList& newParams)
 {
-    params.setParameters(newParams);
+    params_.setParameters(newParams);
 
-    loadSalinityFlux_    = params.get<bool>("Load salinity flux");
-    saveSalinityFlux_    = params.get<bool>("Save salinity flux");
-    loadTemperatureFlux_ = params.get<bool>("Load temperature flux");
-    saveTemperatureFlux_ = params.get<bool>("Save temperature flux");
+    loadSalinityFlux_    = params_.get<bool>("Load salinity flux");
+    saveSalinityFlux_    = params_.get<bool>("Save salinity flux");
+    loadTemperatureFlux_ = params_.get<bool>("Load temperature flux");
+    saveTemperatureFlux_ = params_.get<bool>("Save temperature flux");
 
-    useFort3_            = params.get<bool>("Use legacy fort.3 output");
-    useFort44_           = params.get<bool>("Use legacy fort.44 output");
-    saveColumnIntegral_  = params.get<bool>("Save column integral");
-    maxMaskFixes_        = params.get<int>("Max mask fixes");
+    useFort3_            = params_.get<bool>("Use legacy fort.3 output");
+    useFort44_           = params_.get<bool>("Use legacy fort.44 output");
+    saveColumnIntegral_  = params_.get<bool>("Save column integral");
+    maxMaskFixes_        = params_.get<int>("Max mask fixes");
 
-    landmaskFile_        = params.sublist("THCM").get<std::string>("Land Mask");
-    analyzeJacobian_     = params.get<bool>("Analyze Jacobian");
+    landmaskFile_        = params_.sublist("THCM").get<std::string>("Land Mask");
+    analyzeJacobian_     = params_.get<bool>("Analyze Jacobian");
 
     // inherited input/output datamembers
-    inputFile_   = params.get<std::string>("Input file");
-    outputFile_  = params.get<std::string>("Output file");
-    saveMask_    = params.get<bool>("Save mask");
-    loadMask_    = params.get<bool>("Load mask");
+    inputFile_   = params_.get<std::string>("Input file");
+    outputFile_  = params_.get<std::string>("Output file");
+    saveMask_    = params_.get<bool>("Save mask");
+    loadMask_    = params_.get<bool>("Load mask");
 
-    loadState_   = params.get<bool>("Load state");
-    saveState_   = params.get<bool>("Save state");
-    saveEvery_   = params.get<int>("Save frequency");
+    loadState_   = params_.get<bool>("Load state");
+    saveState_   = params_.get<bool>("Save state");
+    saveEvery_   = params_.get<int>("Save frequency");
 }
 
 const Teuchos::ParameterList

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -81,7 +81,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, Teuchos::RCP<Teuchos::ParameterList> oceanPa
     thcm_ = rcp(new THCM(thcmList, comm_));
 
     Teuchos::ParameterList empty;
-    setParameters(empty);  // note: setParameters needs tcm_ to exist
+    setParameters(empty);  // note: setParameters needs thcm_ to exist
 
     // Throw a few errors if the parameters are odd
     if ((thcm_->getSRES() || thcm_->getITS()) && loadSalinityFlux_)
@@ -2230,8 +2230,8 @@ const Teuchos::ParameterList& Ocean::getParameters()
 void Ocean::setParameters(Teuchos::ParameterList& newParams)
 {
     Teuchos::ParameterList tmpParams(*params_);    
-    tmpParams.setParameters(newParams);    
-    thcm_->setParameters(tmpParams.sublist("THCM"));
+    tmpParams.setParameters(newParams);
+    thcm_->setParameters(newParams.sublist("THCM"));
     tmpParams.validateParametersAndSetDefaults(getDefaultInitParameters());
 
     params_->setParameters(tmpParams);

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -2280,7 +2280,6 @@ void Ocean::setInitParameters(Teuchos::ParameterList newParams)
 
 void Ocean::setParameters(Teuchos::ParameterList newParams)
 {
-    setDefaultParameters(newParams);
-    params_ = newParams;
+    params_.setParameters(newParams);
     setOceanParameters();
 }

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -65,7 +65,8 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, Teuchos::RCP<Teuchos::ParameterList> oceanPa
     recompMassMat_         (true)    // We need a mass matrix to start with
 {
     INFO("Ocean: constructor...");
-    setParameters();
+    Teuchos::ParameterList empty;
+    setParameters(empty);
 
     // initialize postprocessing counter
     ppCtr_ = 0;
@@ -2225,7 +2226,7 @@ Ocean::getDefaultParameters()
 const Teuchos::ParameterList& Ocean::getParameters()
 { return *params_; }
 
-void Ocean::setParameters(Teuchos::ParameterList&& newParams)
+void Ocean::setParameters(Teuchos::ParameterList& newParams)
 {
     params_->setParameters(newParams);
     params_->validateParametersAndSetDefaults(getDefaultInitParameters());
@@ -2251,4 +2252,6 @@ void Ocean::setParameters(Teuchos::ParameterList&& newParams)
     loadState_   = params_->get<bool>("Load state");
     saveState_   = params_->get<bool>("Save state");
     saveEvery_   = params_->get<int>("Save frequency");
+
+    newParams = *params_;
 }

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -68,7 +68,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, const Teuchos::ParameterList& oceanParamList
     recompMassMat_         (true)    // We need a mass matrix to start with
 {
     INFO("Ocean: constructor...");
-    setInitParameters(oceanParamList);
+    setParameters(oceanParamList);
 
     // initialize postprocessing counter
     ppCtr_ = 0;
@@ -2180,64 +2180,11 @@ void Ocean::setPar(std::string const &parName, double value)
 
 //====================================================================
 
-static Teuchos::ParameterList&
-setParams(Teuchos::ParameterList& params)
-{
-    params.get("Load salinity flux", false);
-    params.get("Save salinity flux", true);
-    params.get("Load temperature flux", false);
-    params.get("Save temperature flux", true);
-
-    params.get("Use legacy fort.3 output", false);
-    params.get("Use legacy fort.44 output", true);
-    params.get("Save column integral", false);
-    params.get("Max mask fixes", 5);
-
-    params.get("Analyze Jacobian", true);
-
-    params.get("Input file",  "ocean_input.h5");
-    params.get("Output file", "ocean_output.h5");
-    params.get("Save mask", true);
-    params.get("Load mask", true);
-
-    params.get("Load state", false);
-    params.get("Save state", true);
-    params.get("Save frequency", 0);
-    params.get("Store everything", false);
-
-    Teuchos::ParameterList& solverParams = params.sublist("Belos Solver");
-    solverParams.get("FGMRES iterations", 500);
-    solverParams.get("FGMRES tolerance", 1e-8);
-    solverParams.get("FGMRES restarts", 0);
-    solverParams.get("FGMRES output", 100);
-    solverParams.get("FGMRES explicit residual test", false);
-
-    return params;
-}
-
-Teuchos::ParameterList&
-Ocean::setDefaultInitParameters(Teuchos::ParameterList& params)
-{
-    setParams(params);
-    params.sublist("THCM") = THCM::getDefaultInitParameters();
-
-    return params;
-}
-
-Teuchos::ParameterList&
-Ocean::setDefaultParameters(Teuchos::ParameterList& params)
-{
-    setParams(params);
-    params.sublist("THCM") = THCM::getDefaultParameters();
-
-    return params;
-}
-
 Teuchos::ParameterList
 Ocean::getDefaultInitParameters()
 {
-    Teuchos::ParameterList result;
-    Ocean::setDefaultInitParameters(result);
+    Teuchos::ParameterList result = getDefaultParameters();
+    result.sublist("THCM") = THCM::getDefaultInitParameters();
     return result;
 }
 
@@ -2245,15 +2192,48 @@ Teuchos::ParameterList
 Ocean::getDefaultParameters()
 {
     Teuchos::ParameterList result;
-    Ocean::setDefaultParameters(result);
+    result.get("Load salinity flux", false);
+    result.get("Save salinity flux", true);
+    result.get("Load temperature flux", false);
+    result.get("Save temperature flux", true);
+
+    result.get("Use legacy fort.3 output", false);
+    result.get("Use legacy fort.44 output", true);
+    result.get("Save column integral", false);
+    result.get("Max mask fixes", 5);
+
+    result.get("Analyze Jacobian", true);
+
+    result.get("Input file",  "ocean_input.h5");
+    result.get("Output file", "ocean_output.h5");
+    result.get("Save mask", true);
+    result.get("Load mask", true);
+
+    result.get("Load state", false);
+    result.get("Save state", true);
+    result.get("Save frequency", 0);
+    result.get("Store everything", false);
+
+    Teuchos::ParameterList& solverParams = result.sublist("Belos Solver");
+    solverParams.get("FGMRES iterations", 500);
+    solverParams.get("FGMRES tolerance", 1e-8);
+    solverParams.get("FGMRES restarts", 0);
+    solverParams.get("FGMRES output", 100);
+    solverParams.get("FGMRES explicit residual test", false);
+
+    result.sublist("THCM") = THCM::getDefaultParameters();
+
     return result;
 }
 
 const Teuchos::ParameterList& Ocean::getParameters()
 { return params_; }
 
-void Ocean::setOceanParameters()
+void Ocean::setParameters(Teuchos::ParameterList newParams)
 {
+    params_.setParameters(newParams);
+    params_.validateParametersAndSetDefaults(getDefaultInitParameters());
+
     loadSalinityFlux_    = params_.get<bool>("Load salinity flux");
     saveSalinityFlux_    = params_.get<bool>("Save salinity flux");
     loadTemperatureFlux_ = params_.get<bool>("Load temperature flux");
@@ -2275,19 +2255,4 @@ void Ocean::setOceanParameters()
     loadState_   = params_.get<bool>("Load state");
     saveState_   = params_.get<bool>("Save state");
     saveEvery_   = params_.get<int>("Save frequency");
-}
-
-void Ocean::setInitParameters(Teuchos::ParameterList newParams)
-{
-    setDefaultInitParameters(newParams);
-    newParams.validateParameters(getDefaultInitParameters());
-    params_ = newParams;
-    setOceanParameters();
-}
-
-void Ocean::setParameters(Teuchos::ParameterList newParams)
-{
-    newParams.validateParameters(getDefaultParameters());
-    params_.setParameters(newParams);
-    setOceanParameters();
 }

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -58,7 +58,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm)
 
 Ocean::Ocean(RCP<Epetra_Comm> Comm, Teuchos::RCP<Teuchos::ParameterList> oceanParamList)
     :
-    params_                (oceanParamList),
+    params_                (Teuchos::rcp(new Teuchos::ParameterList)),
     solverInitialized_     (false),  // Solver needs initialization
     precInitialized_       (false),  // Preconditioner needs initialization
     recompPreconditioner_  (true),   // We need a preconditioner to start with
@@ -80,8 +80,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, Teuchos::RCP<Teuchos::ParameterList> oceanPa
 
     thcm_ = rcp(new THCM(thcmList, comm_));
 
-    Teuchos::ParameterList empty;
-    setParameters(empty);  // note: setParameters needs thcm_ to exist
+    setParameters(*oceanParamList);  // note: setParameters needs thcm_ to exist
 
     // Throw a few errors if the parameters are odd
     if ((thcm_->getSRES() || thcm_->getITS()) && loadSalinityFlux_)
@@ -2225,7 +2224,10 @@ Ocean::getDefaultParameters()
 }
 
 const Teuchos::ParameterList& Ocean::getParameters()
-{ return *params_; }
+{ 
+  params_->sublist("THCM")=thcm_->getParameters();
+  return *params_; 
+}
 
 void Ocean::setParameters(Teuchos::ParameterList& newParams)
 {

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -2198,29 +2198,3 @@ void Ocean::setPar(std::string const &parName, double value)
     if (parIdent > 0 && parIdent <= _NPAR_)
         FNAME(setparcs)(&parIdent, &value);
 }
-
-//====================================================================
-void Ocean::setParameters(ParameterList pars)
-{
-    std::string parName;
-    double parValue;
-    // This is similar to reading from HDF5
-    for (int par = 1; par <= _NPAR_; ++par)
-    {
-        parName  = THCM::Instance().int2par(par);
-        parValue = getPar(parName);
-
-        // Overwrite continuation parameter and put it in THCM
-        try
-        {
-            parValue = pars->get(parName, parValue);
-        }
-        catch (EpetraExt::Exception &e)
-        {
-            e.Print();
-            continue;
-        }
-
-        setPar(parName, parValue);
-    }
-}

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -95,7 +95,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, ParameterList oceanParamList)
     //  THCM is implemented as a Singleton, which allows only a single
     //  instance at a time. The Ocean class can access THCM with a call
     //  to THCM::Instance()
-    Teuchos::ParameterList &thcmList =
+    const Teuchos::ParameterList &thcmList =
         oceanParamList->sublist("THCM");
 
     thcm_ = rcp(new THCM(thcmList, comm_));
@@ -128,7 +128,7 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, ParameterList oceanParamList)
     grid_   = rcp(new OceanGrid(domain_));
 
     // Read starting parameters from xml
-    Teuchos::ParameterList& startList =
+    const Teuchos::ParameterList& startList =
         thcmList.sublist("Starting Parameters");
     THCM::Instance().ReadParameters(startList);
 

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -987,7 +987,7 @@ void Ocean::initializeBelos()
     int maxiters          = NumGlobalElements/blocksize - 1;
 
     // Create Belos parameterlist
-    belosParamList_ = rcp(new Teuchos::ParameterList());
+    RCP<Teuchos::ParameterList> belosParamList_ = rcp(new Teuchos::ParameterList());
     belosParamList_->set("Block Size", blocksize);
     belosParamList_->set("Flexible Gmres", true);
     belosParamList_->set("Adaptive Block Size", true);

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -112,11 +112,6 @@ Ocean::Ocean(RCP<Epetra_Comm> Comm, const Teuchos::ParameterList& oceanParamList
     // grid representation of te state
     grid_   = rcp(new OceanGrid(domain_));
 
-    // Read starting parameters from xml
-    const Teuchos::ParameterList& startList =
-        thcmList.sublist("Starting Parameters");
-    THCM::Instance().ReadParameters(startList);
-
     // If specified we load a pre-existing state and parameters (x,l)
     // thereby overwriting the starting parameters
     // This will be able to load salinity and temperature fluxes as well.

--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -921,9 +921,6 @@ void Ocean::initializeSolver()
 {
     INFO("Ocean: initialize solver...");
 
-    solverParams_ = rcp(new Teuchos::ParameterList);
-    updateParametersFromXmlFile("solver_params.xml", solverParams_.ptr());
-
     // Initialize the preconditioner
     if (!precInitialized_)
         initializePreconditioner();
@@ -955,12 +952,14 @@ void Ocean::initializeBelos()
 
     problem_->setRightPrec(belosPrec);
 
+    const Teuchos::ParameterList &belosParams = params_.sublist("Belos Solver");
+
     // A few FGMRES parameters are made available in solver_params.xml:
-    int gmresIters  = solverParams_->get("FGMRES iterations", 500);
-    double gmresTol = solverParams_->get("FGMRES tolerance", 1e-8);
-    int maxrestarts = solverParams_->get("FGMRES restarts", 0);
-    int output      = solverParams_->get("FGMRES output", 100);
-    bool testExpl   = solverParams_->get("FGMRES explicit residual test", false);
+    int gmresIters  = belosParams.get<int>("FGMRES iterations");
+    double gmresTol = belosParams.get<double>("FGMRES tolerance");
+    int maxrestarts = belosParams.get<int>("FGMRES restarts");
+    int output      = belosParams.get<int>("FGMRES output");
+    bool testExpl   = belosParams.get<bool>("FGMRES explicit residual test");
 
     int NumGlobalElements = state_->GlobalLength();
     int blocksize         = 1; // number of vectors in rhs
@@ -2206,6 +2205,13 @@ setParams(Teuchos::ParameterList& params)
     params.get("Save frequency", 0);
     params.get("Store everything", false);
 
+    Teuchos::ParameterList& solverParams = params.sublist("Belos Solver");
+    solverParams.get("FGMRES iterations", 500);
+    solverParams.get("FGMRES tolerance", 1e-8);
+    solverParams.get("FGMRES restarts", 0);
+    solverParams.get("FGMRES output", 100);
+    solverParams.get("FGMRES explicit residual test", false);
+
     return params;
 }
 
@@ -2213,7 +2219,7 @@ Teuchos::ParameterList&
 Ocean::setDefaultInitParameters(Teuchos::ParameterList& params)
 {
     setParams(params);
-    params.sublist("THCM") =  THCM::getDefaultInitParameters();
+    params.sublist("THCM") = THCM::getDefaultInitParameters();
 
     return params;
 }
@@ -2222,7 +2228,7 @@ Teuchos::ParameterList&
 Ocean::setDefaultParameters(Teuchos::ParameterList& params)
 {
     setParams(params);
-    params.sublist("THCM") =  THCM::getDefaultParameters();
+    params.sublist("THCM") = THCM::getDefaultParameters();
 
     return params;
 }

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -165,7 +165,7 @@ public:
     Teuchos::RCP<Epetra_Comm> Comm() const { return comm_; }
 
     const Teuchos::ParameterList& getParameters();
-    void setParameters(Teuchos::ParameterList&& oceanParamList = Teuchos::ParameterList());
+    void setParameters(Teuchos::ParameterList& oceanParamList);
 
     static Teuchos::ParameterList getDefaultInitParameters();
     static Teuchos::ParameterList getDefaultParameters();

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -381,8 +381,6 @@ public:
     VectorPtr getRowScaling();
     VectorPtr getColScaling();
 
-    void setParameters(ParameterList pars);
-
     void copyMask(std::string const &fname);
 
     void dumpBlocks()

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -132,9 +132,6 @@ protected:
     //! Maximum number of mask fixing cycles
     int maxMaskFixes_;
 
-    //! Landmask file
-    std::string landmaskFile_;
-
     //! Select Jacobian analysis
     bool analyzeJacobian_;
 
@@ -170,8 +167,10 @@ public:
     Teuchos::RCP<Epetra_Comm> Comm() const { return comm_; }
 
     const Teuchos::ParameterList& getParameters();
+    void setInitParameters(Teuchos::ParameterList);
     void setParameters(Teuchos::ParameterList);
 
+    static Teuchos::ParameterList getDefaultInitParameters();
     static Teuchos::ParameterList getDefaultParameters();
 
     //! Solve may optionally accept an rhs of VectorPointer type
@@ -436,6 +435,8 @@ private:
 
     void inspectVector(VectorPtr x);
 
+    void setOceanParameters();
+    static Teuchos::ParameterList& setDefaultInitParameters(Teuchos::ParameterList&);
     static Teuchos::ParameterList& setDefaultParameters(Teuchos::ParameterList&);
 };
 #endif

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -94,8 +94,6 @@ protected:
     // grid representation of the state
     mutable Teuchos::RCP<OceanGrid> grid_;
 
-    ParameterList solverParams_;
-
     // Belos flexible GMRES members
     Teuchos::RCP<Belos::LinearProblem
                  <double, Epetra_MultiVector, Epetra_Operator> > problem_;

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -165,7 +165,7 @@ public:
     Teuchos::RCP<Epetra_Comm> Comm() const { return comm_; }
 
     const Teuchos::ParameterList& getParameters();
-    void setParameters(Teuchos::ParameterList);
+    void setParameters(Teuchos::ParameterList oceanParamList);
 
     static Teuchos::ParameterList getDefaultInitParameters();
     static Teuchos::ParameterList getDefaultParameters();

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -157,8 +157,8 @@ protected:
 
 public:
     //! constructor
-    Ocean(Teuchos::RCP<Epetra_Comm> Comm,
-          ParameterList oceanParamList);
+    Ocean(Teuchos::RCP<Epetra_Comm> Comm, Model::ParameterList oceanParamList);
+    Ocean(Teuchos::RCP<Epetra_Comm> Comm, Teuchos::ParameterList& oceanParamList);
 
     //! destructor
     ~Ocean();

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -170,9 +170,9 @@ public:
     Teuchos::RCP<Epetra_Comm> Comm() const { return comm_; }
 
     const Teuchos::ParameterList& getParameters();
-    void setParameters(const Teuchos::ParameterList&);
+    void setParameters(Teuchos::ParameterList);
 
-    static const Teuchos::ParameterList& defaultParameters();
+    static Teuchos::ParameterList getDefaultParameters();
 
     //! Solve may optionally accept an rhs of VectorPointer type
     void solve(Teuchos::RCP<const Epetra_MultiVector> rhs = Teuchos::null);
@@ -436,6 +436,6 @@ private:
 
     void inspectVector(VectorPtr x);
 
-    static const Teuchos::ParameterList defaultParams;
+    static Teuchos::ParameterList& setDefaultParameters(Teuchos::ParameterList&);
 };
 #endif

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -155,6 +155,7 @@ public:
     //! constructor
     Ocean(Teuchos::RCP<Epetra_Comm> Comm);
     Ocean(Teuchos::RCP<Epetra_Comm> Comm, Model::ParameterList oceanParamList);
+    Ocean(Teuchos::RCP<Epetra_Comm> Comm, Teuchos::ParameterList& oceanParamList);
 
     //! destructor
     ~Ocean();

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -165,7 +165,6 @@ public:
     Teuchos::RCP<Epetra_Comm> Comm() const { return comm_; }
 
     const Teuchos::ParameterList& getParameters();
-    void setInitParameters(Teuchos::ParameterList);
     void setParameters(Teuchos::ParameterList);
 
     static Teuchos::ParameterList getDefaultInitParameters();
@@ -432,9 +431,5 @@ private:
     Teuchos::RCP<Epetra_Vector> initialState();
 
     void inspectVector(VectorPtr x);
-
-    void setOceanParameters();
-    static Teuchos::ParameterList& setDefaultInitParameters(Teuchos::ParameterList&);
-    static Teuchos::ParameterList& setDefaultParameters(Teuchos::ParameterList&);
 };
 #endif

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -63,7 +63,7 @@ public:
     using LandMask  = Utils::MaskStruct;
 
 protected:
-    Teuchos::ParameterList params_;
+    Teuchos::RCP<Teuchos::ParameterList> params_;
 
     Teuchos::RCP<THCM> thcm_;
 
@@ -165,7 +165,7 @@ public:
     Teuchos::RCP<Epetra_Comm> Comm() const { return comm_; }
 
     const Teuchos::ParameterList& getParameters();
-    void setParameters(Teuchos::ParameterList oceanParamList);
+    void setParameters(Teuchos::ParameterList&& oceanParamList = Teuchos::ParameterList());
 
     static Teuchos::ParameterList getDefaultInitParameters();
     static Teuchos::ParameterList getDefaultParameters();

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -63,6 +63,7 @@ public:
     using LandMask  = Utils::MaskStruct;
 
 protected:
+    Teuchos::ParameterList params;
 
     Teuchos::RCP<THCM> thcm_;
 
@@ -157,8 +158,9 @@ protected:
 
 public:
     //! constructor
+    Ocean(Teuchos::RCP<Epetra_Comm> Comm);
     Ocean(Teuchos::RCP<Epetra_Comm> Comm, Model::ParameterList oceanParamList);
-    Ocean(Teuchos::RCP<Epetra_Comm> Comm, Teuchos::ParameterList& oceanParamList);
+    Ocean(Teuchos::RCP<Epetra_Comm> Comm, const Teuchos::ParameterList& oceanParamList);
 
     //! destructor
     ~Ocean();
@@ -166,6 +168,11 @@ public:
     std::string name() const { return "ocean"; }
     int modelIdent() const { return 0; }
     Teuchos::RCP<Epetra_Comm> Comm() const { return comm_; }
+
+    const Teuchos::ParameterList& getParameters();
+    void setParameters(const Teuchos::ParameterList&);
+
+    static const Teuchos::ParameterList& defaultParameters();
 
     //! Solve may optionally accept an rhs of VectorPointer type
     void solve(Teuchos::RCP<const Epetra_MultiVector> rhs = Teuchos::null);
@@ -428,5 +435,7 @@ private:
     Teuchos::RCP<Epetra_Vector> initialState();
 
     void inspectVector(VectorPtr x);
+
+    static const Teuchos::ParameterList defaultParams;
 };
 #endif

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -155,7 +155,6 @@ public:
     //! constructor
     Ocean(Teuchos::RCP<Epetra_Comm> Comm);
     Ocean(Teuchos::RCP<Epetra_Comm> Comm, Model::ParameterList oceanParamList);
-    Ocean(Teuchos::RCP<Epetra_Comm> Comm, const Teuchos::ParameterList& oceanParamList);
 
     //! destructor
     ~Ocean();

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -63,7 +63,7 @@ public:
     using LandMask  = Utils::MaskStruct;
 
 protected:
-    Teuchos::ParameterList params;
+    Teuchos::ParameterList params_;
 
     Teuchos::RCP<THCM> thcm_;
 

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -96,7 +96,6 @@ protected:
     ParameterList solverParams_;
 
     // Belos flexible GMRES members
-    ParameterList belosParamList_;
     Teuchos::RCP<Belos::LinearProblem
                  <double, Epetra_MultiVector, Epetra_Operator> > problem_;
     Teuchos::RCP<Belos::BlockGmresSolMgr

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -182,7 +182,7 @@ extern "C" {
 
 //=============================================================================
 // constructor
-THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
+THCM::THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm> comm) :
     Singleton<THCM>(Teuchos::rcp(this, false)),
     Comm(comm),
     nullSpace(Teuchos::null),
@@ -190,10 +190,10 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
 {
     DEBUG("### enter THCM::THCM ###");
 
-    paramList.validateParametersAndSetDefaults(getDefaultInitParameters());
+    paramList->validateParametersAndSetDefaults(getDefaultInitParameters());
     setPreParameters();
 
-    std::string probdesc = paramList.get<std::string>("Problem Description");
+    std::string probdesc = paramList->get<std::string>("Problem Description");
 
     std::stringstream ss;
     ss << "THCM (" << probdesc <<", "
@@ -210,16 +210,16 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
                 << xdist, __FILE__, __LINE__);
     }
 
-    double qz      = paramList.get<double>("Grid Stretching qz");
-    int    itopo   = paramList.get<int>("Topography");
-    bool   flat    = paramList.get<bool>("Flat Bottom");
-    bool   rd_mask = paramList.get<bool>("Read Land Mask"); //== false in experiment0
+    double qz      = paramList->get<double>("Grid Stretching qz");
+    int    itopo   = paramList->get<int>("Topography");
+    bool   flat    = paramList->get<bool>("Flat Bottom");
+    bool   rd_mask = paramList->get<bool>("Read Land Mask"); //== false in experiment0
 
     if (rd_mask)
     {
         // we put the name of the desired mask in a file so it can be
         // obtained from there by the fortran code:
-        std::string mask_file = paramList.get<std::string>("Land Mask");
+        std::string mask_file = paramList->get<std::string>("Land Mask");
         if (Comm->MyPID() == 0)
         {
             std::ofstream mfs("mask_name.txt", std::ios::trunc);
@@ -227,8 +227,8 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
         }
     }
 
-    int coriolis_on  = paramList.get<int>("Coriolis Force");
-    int forcing_type = paramList.get<int>("Forcing Type");
+    int coriolis_on  = paramList->get<int>("Coriolis Force");
+    int forcing_type = paramList->get<int>("Forcing Type");
 
     //------------------------------------------------------------------
     if ((coupled_S == 1) && (sres == 1))
@@ -239,10 +239,10 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
         sres = 0;
     }
 
-    bool rd_spertm = paramList.get<bool>("Read Salinity Perturbation Mask");
+    bool rd_spertm = paramList->get<bool>("Read Salinity Perturbation Mask");
     if (rd_spertm)
     {
-        std::string spertm_file = paramList.get<std::string>("Salinity Perturbation Mask");
+        std::string spertm_file = paramList->get<std::string>("Salinity Perturbation Mask");
         if (Comm->MyPID()==0)
         {
             std::ofstream mfs("spertm_name.txt",std::ios::trunc);
@@ -262,11 +262,11 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
         std::ofstream sstfile("sstf_name.txt",   std::ios::trunc);
         std::ofstream sssfile("sssf_name.txt",   std::ios::trunc);
         // Let THCM know the wind forcing file
-        windfile << paramList.get<std::string>("Wind Forcing Data");
+        windfile << paramList->get<std::string>("Wind Forcing Data");
         // Let THCM know the sst forcing file
-        sstfile  << paramList.get<std::string>("Temperature Forcing Data");
+        sstfile  << paramList->get<std::string>("Temperature Forcing Data");
         // Let THCM know the sss forcing file
-        sssfile  << paramList.get<std::string>("Salinity Forcing Data");
+        sssfile  << paramList->get<std::string>("Salinity Forcing Data");
     }
     //-----------------------------------------------------------------
 
@@ -595,7 +595,7 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
         F90NAME(m_usr,set_internal_forcing)(temp,salt);
     }
 
-    bool time_dep_forcing = paramList.get<bool>("Time Dependent Forcing");
+    bool time_dep_forcing = paramList->get<bool>("Time Dependent Forcing");
     if (time_dep_forcing)
     {
         // read and distribute Levitus data
@@ -662,11 +662,11 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
     int M = domain->GlobalM();
     int L = domain->GlobalL();
 
-    int Nic = paramList.get<int>("Integral row coordinate i");
+    int Nic = paramList->get<int>("Integral row coordinate i");
     if (Nic == -1) {
         Nic = N-1;
     }
-    int Mic = paramList.get<int>("Integral row coordinate j");
+    int Mic = paramList->get<int>("Integral row coordinate j");
     if (Mic == -1) {
         Mic = M-1;
     }
@@ -781,7 +781,7 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
     // build vector with integral coefficients
     this->evaluateB();
 
-    scaling_type=paramList.get<std::string>("Scaling");
+    scaling_type=paramList->get<std::string>("Scaling");
 
     if (scaling_type=="THCM")
     {
@@ -2025,7 +2025,7 @@ bool THCM::setParameter(std::string label, double value)
     else if (param==0) // 0 is non-dimensional time
     {
         // set monthly forcing data
-        bool time_dep_forcing = paramList.get<bool>("Time Dependent Forcing");
+        bool time_dep_forcing = paramList->get<bool>("Time Dependent Forcing");
         if ((value>=0.0) && time_dep_forcing)
         {
             double gamma=1.0,gammaT=1.0,gammaS=1.0,gammaW=1.0;//default values
@@ -3066,64 +3066,65 @@ THCM::getDefaultParameters()
 }
 
 const Teuchos::ParameterList& THCM::getParameters()
-{ return paramList; }
+{ return *paramList; }
 
 void THCM::setPreParameters()
 {
-    n = paramList.get<int>("Global Grid-Size n");
-    m = paramList.get<int>("Global Grid-Size m");
-    l = paramList.get<int>("Global Grid-Size l");
+    n = paramList->get<int>("Global Grid-Size n");
+    m = paramList->get<int>("Global Grid-Size m");
+    l = paramList->get<int>("Global Grid-Size l");
 
     // default: north atlantic
-    xmin = paramList.get<double>("Global Bound xmin") * PI_ / 180.0;
-    xmax = paramList.get<double>("Global Bound xmax") * PI_ / 180.0;
-    ymin = paramList.get<double>("Global Bound ymin") * PI_ / 180.0;
-    ymax = paramList.get<double>("Global Bound ymax") * PI_ / 180.0;
-    periodic           = paramList.get<bool>("Periodic");
+    xmin = paramList->get<double>("Global Bound xmin") * PI_ / 180.0;
+    xmax = paramList->get<double>("Global Bound xmax") * PI_ / 180.0;
+    ymin = paramList->get<double>("Global Bound ymin") * PI_ / 180.0;
+    ymax = paramList->get<double>("Global Bound ymax") * PI_ / 180.0;
+    periodic           = paramList->get<bool>("Periodic");
 
-    hdim               = paramList.get<double>("Depth hdim");
-    comp_sal_int       = paramList.get<bool>("Compute salinity integral");
-    ih                 = paramList.get<int>("Inhomogeneous Mixing");
-    vmix_GLB           = paramList.get<int>("Mixing");
-    rho_mixing         = paramList.get<bool>("Rho Mixing");
-    tap                = paramList.get<int>("Taper");
-    alphaT             = paramList.get<double>("Linear EOS: alpha T");
-    alphaS             = paramList.get<double>("Linear EOS: alpha S");
-    tres               = paramList.get<int>("Restoring Temperature Profile");
-    sres               = paramList.get<int>("Restoring Salinity Profile");
-    localSres_         = paramList.get<bool>("Local SRES Only");
-    intSign_           = paramList.get<int>("Salinity Integral Sign");
-    ite                = paramList.get<int>("Levitus T");
-    its                = paramList.get<int>("Levitus S");
-    internal_forcing   = paramList.get<bool>("Levitus Internal T/S");
-    coupled_T          = paramList.get<int>("Coupled Temperature");
-    coupled_S          = paramList.get<int>("Coupled Salinity");
-    coupled_M          = paramList.get<int>("Coupled Sea Ice Mask");
-    fixPressurePoints_ = paramList.get<bool>("Fix Pressure Points");
-    iza                = paramList.get<int>("Wind Forcing Type");
+    hdim               = paramList->get<double>("Depth hdim");
+    comp_sal_int       = paramList->get<bool>("Compute salinity integral");
+    ih                 = paramList->get<int>("Inhomogeneous Mixing");
+    vmix_GLB           = paramList->get<int>("Mixing");
+    rho_mixing         = paramList->get<bool>("Rho Mixing");
+    tap                = paramList->get<int>("Taper");
+    alphaT             = paramList->get<double>("Linear EOS: alpha T");
+    alphaS             = paramList->get<double>("Linear EOS: alpha S");
+    tres               = paramList->get<int>("Restoring Temperature Profile");
+    sres               = paramList->get<int>("Restoring Salinity Profile");
+    localSres_         = paramList->get<bool>("Local SRES Only");
+    intSign_           = paramList->get<int>("Salinity Integral Sign");
+    ite                = paramList->get<int>("Levitus T");
+    its                = paramList->get<int>("Levitus S");
+    internal_forcing   = paramList->get<bool>("Levitus Internal T/S");
+    coupled_T          = paramList->get<int>("Coupled Temperature");
+    coupled_S          = paramList->get<int>("Coupled Salinity");
+    coupled_M          = paramList->get<int>("Coupled Sea Ice Mask");
+    fixPressurePoints_ = paramList->get<bool>("Fix Pressure Points");
+    iza                = paramList->get<int>("Wind Forcing Type");
 
-    scaling_type       = paramList.get<std::string>("Scaling");
+    scaling_type       = paramList->get<std::string>("Scaling");
 }
 
 void THCM::setPostParameters()
 {
     double value; //Only used to determine return type of getValue
-    for (const auto& param : paramList.sublist("Starting Parameters")) {
+    for (const auto& param : paramList->sublist("Starting Parameters")) {
         if (!std::isnan(param.second.getValue(&value))) {
             this->setParameter(param.first, param.second.getValue(&value));
         } else {
-            int p = par2int(param.first);
+            std::string name = param.first;
+            int p = par2int(name);
             FNAME(getparcs)(&p,&value);
-            paramList.sublist("Starting Parameters").remove(param.first);
-            paramList.sublist("Starting Parameters").get(param.first, value);
+            paramList->sublist("Starting Parameters").remove(name);
+            paramList->sublist("Starting Parameters").get(name, value);
         }
     }
 }
 
-void THCM::setParameters(Teuchos::ParameterList newParams)
+void THCM::setParameters(const Teuchos::ParameterList&& newParams)
 {
-    paramList.setParameters(newParams);
-    paramList.validateParametersAndSetDefaults(getDefaultInitParameters());
+    paramList->setParameters(newParams);
+    paramList->validateParametersAndSetDefaults(getDefaultInitParameters());
 
     setPreParameters();
     setPostParameters();

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -182,7 +182,7 @@ extern "C" {
 
 //=============================================================================
 // constructor
-THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
+THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     Singleton<THCM>(Teuchos::rcp(this, false)),
     Comm(comm),
     nullSpace(Teuchos::null),
@@ -1891,7 +1891,7 @@ void THCM::printTiming(std::ostream& os)
 }
 
 //=============================================================================
-void THCM::ReadParameters(Teuchos::ParameterList& plist)
+void THCM::ReadParameters(const Teuchos::ParameterList& plist)
 {
     double val;
     std::string label;
@@ -1899,9 +1899,8 @@ void THCM::ReadParameters(Teuchos::ParameterList& plist)
         for (int i=0; i<= _NPAR_ + _NPAR_TRILI; i++)
         {
             label = int2par(i);
-            if (plist.isParameter(label))
-            {
-                val = plist.get(label,defaultParameter(label));
+            if (plist.isParameter(label)) {
+                val = plist.get<double>(label);
                 this->setParameter(label,val);
             }
         }

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -1855,13 +1855,34 @@ void THCM::printTiming(std::ostream& os)
 //=============================================================================
 double THCM::defaultParameter(std::string const &label)
 {
-    if (!label.compare("Combined Forcing"))    return 0.0;
-    if (!label.compare("Solar Forcing"))       return 0.0;
-    if (!label.compare("Salinity Forcing"))    return 1.0;
-    if (!label.compare("Wind Forcing"))        return 1.0;
-    if (!label.compare("Temperature Forcing")) return 10.0;
-    if (!label.compare("SPL1"))                return 2.0e3;
-    if (!label.compare("SPL2"))                return 0.01;
+    //FIXME: Discuss how to better handle default value for AL_T being
+    //initalised in Fortran code.
+    if (label == "AL_T")                           return std::numeric_limits<double>::quiet_NaN();
+    if (label == "Rayleigh-Number")                return 0x1.59ab28f36fe65p-5; //0.0421959
+    if (label == "Vertical Ekman-Number")          return 0x1.cc276ea10aecep-22; //4.28552e-07
+    if (label == "Horizontal Ekman-Number")        return 0x1.62625cf2ea517p-15; // 4.22459e-05
+    if (label == "Rossby-Number")                  return 0x1.c37c4a6287b49p-14; //0.000107643
+    if (label == "SPL1")                           return 0x1.f4p+10; //2000
+    if (label == "Solar Forcing")                  return 0x0p+0; //0
+    if (label == "Horizontal Peclet-Number")       return 0x1.9b876f5262dd1p-10; //0.00156986
+    if (label == "Vertical Peclet-Number")         return 0x1.a176ddaceee0fp-12; //0.000398125
+    if (label == "P_VC")                           return 0x1.3e8p+3; //9.95312
+    if (label == "LAMB")                           return 0x1.e666666666666p+2; //7.6
+    if (label == "Salinity Forcing")               return 0x1p+0; //1
+    if (label == "Wind Forcing")                   return 0x1p+0; //1
+    if (label == "Temperature Forcing")            return 0x1.4p+3; //10
+    if (label == "Nonlinear Factor")               return 0x1.3a9161f9add3cp+3; //9.83025
+    if (label == "Combined Forcing")               return 0x0p+0; //0
+    if (label == "Energy")                         return 0x1.9p+6; //100
+    if (label == "ALPC")                           return 0x1p+0; // 1
+    if (label == "SPL2")                           return 0x1.47ae147ae147bp-7; //0.01
+    if (label == "Exponent")                       return 0x1.47ae147ae147bp-7; //0.01
+    if (label == "Seasonal Forcing")               return 0x1.47ae147ae147bp-7; //0.01
+    if (label == "Seasonal Forcing (Wind)")        return 0x1.47ae147ae147bp-7; //0.01
+    if (label == "Seasonal Forcing (Temperature)") return 0x1.47ae147ae147bp-7; //0.01
+    if (label == "Seasonal Forcing (Salinity)")    return 0x1.47ae147ae147bp-7; //0.01
+    if (label == "Mass")                           return 0x1.47ae147ae147bp-7; //0.01
+
     return 0.0;
 }
 
@@ -3031,14 +3052,12 @@ THCM::setDefaultParameters(Teuchos::ParameterList& params)
     params.get("Wind Forcing Type",2);
     params.get("Scaling","THCM");
 
-    /*
     Teuchos::ParameterList& startParams = params.sublist("Starting Parameters");
     for (int i=0; i<= _NPAR_ + _NPAR_TRILI; i++)
     {
         std::string label = int2par(i);
         startParams.get(label, defaultParameter(label));
     }
-    */
 
     return params;
 }
@@ -3103,7 +3122,9 @@ void THCM::setPostParameters()
 {
     double *val = nullptr; //Only used to determine return type of getValue
     for (const auto& param : paramList.sublist("Starting Parameters")) {
-        this->setParameter(param.first, param.second.getValue(val));
+        if (!std::isnan(param.second.getValue(val))) {
+            this->setParameter(param.first, param.second.getValue(val));
+        }
     }
 }
 

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -3130,6 +3130,16 @@ void THCM::setParameters(Teuchos::ParameterList& newParams)
     paramList->setParameters(tmpParams);
 
     setPreParameters();
+
+    //------------------------------------------------------------------
+    if ((coupled_S == 1) && (sres == 1))
+    {
+        WARNING("Incompatible parameters: coupled_S = " << coupled_S
+                << " sres = "
+                << sres << " setting sres = 0", __FILE__, __LINE__);
+        sres = 0;
+    }
+    
     setPostParameters();
 
     newParams=*paramList;

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -1858,30 +1858,30 @@ double THCM::defaultParameter(std::string const &label)
     //FIXME: Discuss how to better handle default value for AL_T being
     //initalised in Fortran code.
     if (label == "AL_T")                           return std::numeric_limits<double>::quiet_NaN();
-    if (label == "Rayleigh-Number")                return 0x1.59ab28f36fe65p-5; //0.0421959
-    if (label == "Vertical Ekman-Number")          return 0x1.cc276ea10aecep-22; //4.28552e-07
-    if (label == "Horizontal Ekman-Number")        return 0x1.62625cf2ea517p-15; // 4.22459e-05
-    if (label == "Rossby-Number")                  return 0x1.c37c4a6287b49p-14; //0.000107643
-    if (label == "SPL1")                           return 0x1.f4p+10; //2000
-    if (label == "Solar Forcing")                  return 0x0p+0; //0
-    if (label == "Horizontal Peclet-Number")       return 0x1.9b876f5262dd1p-10; //0.00156986
-    if (label == "Vertical Peclet-Number")         return 0x1.a176ddaceee0fp-12; //0.000398125
-    if (label == "P_VC")                           return 0x1.3e8p+3; //9.95312
-    if (label == "LAMB")                           return 0x1.e666666666666p+2; //7.6
-    if (label == "Salinity Forcing")               return 0x1p+0; //1
-    if (label == "Wind Forcing")                   return 0x1p+0; //1
-    if (label == "Temperature Forcing")            return 0x1.4p+3; //10
-    if (label == "Nonlinear Factor")               return 0x1.3a9161f9add3cp+3; //9.83025
-    if (label == "Combined Forcing")               return 0x0p+0; //0
-    if (label == "Energy")                         return 0x1.9p+6; //100
-    if (label == "ALPC")                           return 0x1p+0; // 1
-    if (label == "SPL2")                           return 0x1.47ae147ae147bp-7; //0.01
-    if (label == "Exponent")                       return 0x1.47ae147ae147bp-7; //0.01
-    if (label == "Seasonal Forcing")               return 0x1.47ae147ae147bp-7; //0.01
-    if (label == "Seasonal Forcing (Wind)")        return 0x1.47ae147ae147bp-7; //0.01
-    if (label == "Seasonal Forcing (Temperature)") return 0x1.47ae147ae147bp-7; //0.01
-    if (label == "Seasonal Forcing (Salinity)")    return 0x1.47ae147ae147bp-7; //0.01
-    if (label == "Mass")                           return 0x1.47ae147ae147bp-7; //0.01
+    if (label == "Rayleigh-Number")                return 4.219587324359678e-2;
+    if (label == "Vertical Ekman-Number")          return 4.2855183763027976e-7;
+    if (label == "Horizontal Ekman-Number")        return 4.22458923801749e-5;
+    if (label == "Rossby-Number")                  return 1.0764253378468565e-4;
+    if (label == "SPL1")                           return 2000;
+    if (label == "Solar Forcing")                  return 0;
+    if (label == "Horizontal Peclet-Number")       return 1.5698587127158557e-3;
+    if (label == "Vertical Peclet-Number")         return 3.98125e-4;
+    if (label == "P_VC")                           return 9.95312;
+    if (label == "LAMB")                           return 7.6;
+    if (label == "Salinity Forcing")               return 1;
+    if (label == "Wind Forcing")                   return 1;
+    if (label == "Temperature Forcing")            return 10;
+    if (label == "Nonlinear Factor")               return 9.830246913580247;
+    if (label == "Combined Forcing")               return 0;
+    if (label == "Energy")                         return 100;
+    if (label == "ALPC")                           return 1;
+    if (label == "SPL2")                           return 0.01;
+    if (label == "Exponent")                       return 0.01;
+    if (label == "Seasonal Forcing")               return 0.01;
+    if (label == "Seasonal Forcing (Wind)")        return 0.01;
+    if (label == "Seasonal Forcing (Temperature)") return 0.01;
+    if (label == "Seasonal Forcing (Salinity)")    return 0.01;
+    if (label == "Mass")                           return 0.01;
 
     return 0.0;
 }

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -182,7 +182,13 @@ extern "C" {
 
 //=============================================================================
 // constructor
-THCM::THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm> comm) :
+THCM::THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm> comm)
+    : THCM(*params, comm)
+{}
+
+//=============================================================================
+// constructor
+THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     Singleton<THCM>(Teuchos::rcp(this, false)),
     Comm(comm),
     nullSpace(Teuchos::null),
@@ -190,7 +196,7 @@ THCM::THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm
 {
     DEBUG("### enter THCM::THCM ###");
 
-    *paramList=*params;
+    *paramList=params;
 
     paramList->validateParametersAndSetDefaults(getDefaultInitParameters());
     setPreParameters();
@@ -802,7 +808,7 @@ THCM::THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm
 
     setPostParameters();
 
-    *params=*paramList;
+    params=*paramList;
 }
 
 //=============================================================================
@@ -3127,8 +3133,8 @@ void THCM::setPostParameters()
 
 void THCM::setParameters(Teuchos::ParameterList& newParams)
 {
-    Teuchos::ParameterList tmpParams(*paramList);    
-    tmpParams.setParameters(newParams);    
+    Teuchos::ParameterList tmpParams(*paramList);
+    tmpParams.setParameters(newParams);
     tmpParams.validateParametersAndSetDefaults(getDefaultInitParameters());
 
     paramList->setParameters(tmpParams);

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -3094,15 +3094,9 @@ void THCM::setPreParameters()
 
 void THCM::setPostParameters()
 {
-    double val;
-    std::string label;
-    for (int i=0; i<= _NPAR_ + _NPAR_TRILI; i++)
-    {
-        label = int2par(i);
-        if (paramList.sublist("Starting Parameters").isParameter(label)) {
-            val = paramList.sublist("Starting Parameters").get<double>(label);
-            this->setParameter(label,val);
-        }
+    double *val = nullptr; //Only used to determine return type of getValue
+    for (const auto& param : paramList.sublist("Starting Parameters")) {
+        this->setParameter(param.first, param.second.getValue(val));
     }
 }
 

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -186,9 +186,11 @@ THCM::THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm
     Singleton<THCM>(Teuchos::rcp(this, false)),
     Comm(comm),
     nullSpace(Teuchos::null),
-    paramList(params)
+    paramList(Teuchos::rcp(new Teuchos::ParameterList))
 {
     DEBUG("### enter THCM::THCM ###");
+
+    *paramList=*params;
 
     paramList->validateParametersAndSetDefaults(getDefaultInitParameters());
     setPreParameters();
@@ -799,6 +801,8 @@ THCM::THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm
     }
 
     setPostParameters();
+
+    *params=*paramList;
 }
 
 //=============================================================================

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -663,9 +663,8 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
     int M = domain->GlobalM();
     int L = domain->GlobalL();
 
-    //FIXME: Problem!
-    int Nic = paramList.get("Integral row coordinate i", N-1);
-    int Mic = paramList.get("Integral row coordinate j", M-1);
+    int Nic = paramList.get<int>("Integral row coordinate i");
+    int Mic = paramList.get<int>("Integral row coordinate j");
     int midx;     // mask index
     int mval = 1; // mask value
     int tmp  = 0;
@@ -2984,7 +2983,15 @@ THCM::setDefaultInitParameters(Teuchos::ParameterList& params)
 
     params.get("Time Dependent Forcing", false);
 
-    return THCM::setDefaultParameters(params);
+    THCM::setDefaultParameters(params);
+
+    int N = params.get<int>("Global Grid-Size n");
+    int M = params.get<int>("Global Grid-Size m");
+
+    params.get("Integral row coordinate i", N-1);
+    params.get("Integral row coordinate j", M-1);
+
+    return params;
 }
 
 Teuchos::ParameterList&

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -3121,11 +3121,16 @@ void THCM::setPostParameters()
     }
 }
 
-void THCM::setParameters(const Teuchos::ParameterList&& newParams)
+void THCM::setParameters(Teuchos::ParameterList& newParams)
 {
-    paramList->setParameters(newParams);
-    paramList->validateParametersAndSetDefaults(getDefaultInitParameters());
+    Teuchos::ParameterList tmpParams(*paramList);    
+    tmpParams.setParameters(newParams);    
+    tmpParams.validateParametersAndSetDefaults(getDefaultInitParameters());
+
+    paramList->setParameters(tmpParams);
 
     setPreParameters();
     setPostParameters();
+
+    newParams=*paramList;
 }

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -190,8 +190,7 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
 {
     DEBUG("### enter THCM::THCM ###");
 
-    setDefaultInitParameters(paramList);
-    paramList.validateParameters(getDefaultInitParameters());
+    paramList.validateParametersAndSetDefaults(getDefaultInitParameters());
     setPreParameters();
 
     std::string probdesc = paramList.get<std::string>("Problem Description");
@@ -664,7 +663,13 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
     int L = domain->GlobalL();
 
     int Nic = paramList.get<int>("Integral row coordinate i");
+    if (Nic == -1) {
+        Nic = N-1;
+    }
     int Mic = paramList.get<int>("Integral row coordinate j");
+    if (Mic == -1) {
+        Mic = M-1;
+    }
     int midx;     // mask index
     int mval = 1; // mask value
     int tmp  = 0;
@@ -2980,93 +2985,35 @@ Teuchos::RCP<const Epetra_MultiVector> THCM::getNullSpace()
 }
 
 //=============================================================================
-Teuchos::ParameterList&
-THCM::setDefaultInitParameters(Teuchos::ParameterList& params)
-{
-    params.get("Problem Description","Unnamed");
-
-    params.get("Grid Stretching qz", 1.0);
-    params.get("Topography", 1);
-    params.get("Flat Bottom", false);
-
-    params.get("Read Land Mask", false); //== false in experiment0
-    params.get("Land Mask","no_mask_specified");
-
-    params.get("Coriolis Force", 1);
-    params.get("Forcing Type", 0);
-
-    params.get("Read Salinity Perturbation Mask",false);
-    params.get("Salinity Perturbation Mask", "no_mask_specified");
-
-    params.get("Wind Forcing Data", "wind/trtau.dat");
-    params.get("Temperature Forcing Data", "levitus/new/t00an1");
-    params.get("Salinity Forcing Data", "levitus/new/s00an1");
-
-    params.get("Time Dependent Forcing", false);
-
-    THCM::setDefaultParameters(params);
-
-    int N = params.get<int>("Global Grid-Size n");
-    int M = params.get<int>("Global Grid-Size m");
-
-    params.get("Integral row coordinate i", N-1);
-    params.get("Integral row coordinate j", M-1);
-
-    return params;
-}
-
-Teuchos::ParameterList&
-THCM::setDefaultParameters(Teuchos::ParameterList& params)
-{
-    params.get("Global Grid-Size n", 16);
-    params.get("Global Grid-Size m", 16);
-    params.get("Global Grid-Size l", 16);
-
-    // default: north atlantic
-    params.get("Global Bound xmin", 286.0);
-    params.get("Global Bound xmax", 350.0);
-    params.get("Global Bound ymin", 10.0);
-    params.get("Global Bound ymax", 74.0);
-    params.get("Periodic", false);
-
-    params.get("Depth hdim", 4000.0);
-    params.get("Compute salinity integral", true);
-
-    params.get("Inhomogeneous Mixing",0);
-    params.get("Mixing",1);
-    params.get("Rho Mixing",true);
-    params.get("Taper",1);
-    params.get("Linear EOS: alpha T", 1.0e-4);
-    params.get("Linear EOS: alpha S", 7.6e-4);
-    params.get("Restoring Temperature Profile",1);
-    params.get("Restoring Salinity Profile",1);
-    params.get("Local SRES Only", false);
-    params.get("Salinity Integral Sign", -1);
-    params.get("Levitus T", 1);
-    params.get("Levitus S", 1);
-    params.get("Levitus Internal T/S",false);
-    params.get("Coupled Temperature", 0);
-    params.get("Coupled Salinity", 0);
-    params.get("Coupled Sea Ice Mask", 1);
-    params.get("Fix Pressure Points", false);
-    params.get("Wind Forcing Type",2);
-    params.get("Scaling","THCM");
-
-    Teuchos::ParameterList& startParams = params.sublist("Starting Parameters");
-    for (int i=0; i<= _NPAR_ + _NPAR_TRILI; i++)
-    {
-        std::string label = int2par(i);
-        startParams.get(label, defaultParameter(label));
-    }
-
-    return params;
-}
-
 Teuchos::ParameterList
 THCM::getDefaultInitParameters()
 {
-    Teuchos::ParameterList result;
-    THCM::setDefaultInitParameters(result);
+    Teuchos::ParameterList result = getDefaultParameters();
+
+    result.get("Problem Description","Unnamed");
+
+    result.get("Grid Stretching qz", 1.0);
+    result.get("Topography", 1);
+    result.get("Flat Bottom", false);
+
+    result.get("Read Land Mask", false); //== false in experiment0
+    result.get("Land Mask","no_mask_specified");
+
+    result.get("Coriolis Force", 1);
+    result.get("Forcing Type", 0);
+
+    result.get("Read Salinity Perturbation Mask",false);
+    result.get("Salinity Perturbation Mask", "no_mask_specified");
+
+    result.get("Wind Forcing Data", "wind/trtau.dat");
+    result.get("Temperature Forcing Data", "levitus/new/t00an1");
+    result.get("Salinity Forcing Data", "levitus/new/s00an1");
+
+    result.get("Time Dependent Forcing", false);
+
+    result.get("Integral row coordinate i", -1);
+    result.get("Integral row coordinate j", -1);
+
     return result;
 }
 
@@ -3074,11 +3021,51 @@ Teuchos::ParameterList
 THCM::getDefaultParameters()
 {
     Teuchos::ParameterList result;
-    THCM::setDefaultParameters(result);
+    result.get("Global Grid-Size n", 16);
+    result.get("Global Grid-Size m", 16);
+    result.get("Global Grid-Size l", 16);
+
+    // default: north atlantic
+    result.get("Global Bound xmin", 286.0);
+    result.get("Global Bound xmax", 350.0);
+    result.get("Global Bound ymin", 10.0);
+    result.get("Global Bound ymax", 74.0);
+    result.get("Periodic", false);
+
+    result.get("Depth hdim", 4000.0);
+    result.get("Compute salinity integral", true);
+
+    result.get("Inhomogeneous Mixing",0);
+    result.get("Mixing",1);
+    result.get("Rho Mixing",true);
+    result.get("Taper",1);
+    result.get("Linear EOS: alpha T", 1.0e-4);
+    result.get("Linear EOS: alpha S", 7.6e-4);
+    result.get("Restoring Temperature Profile",1);
+    result.get("Restoring Salinity Profile",1);
+    result.get("Local SRES Only", false);
+    result.get("Salinity Integral Sign", -1);
+    result.get("Levitus T", 1);
+    result.get("Levitus S", 1);
+    result.get("Levitus Internal T/S",false);
+    result.get("Coupled Temperature", 0);
+    result.get("Coupled Salinity", 0);
+    result.get("Coupled Sea Ice Mask", 1);
+    result.get("Fix Pressure Points", false);
+    result.get("Wind Forcing Type",2);
+    result.get("Scaling","THCM");
+
+    Teuchos::ParameterList& startParams = result.sublist("Starting Parameters");
+    for (int i=0; i<= _NPAR_ + _NPAR_TRILI; i++)
+    {
+        std::string label = int2par(i);
+        startParams.get(label, defaultParameter(label));
+    }
+
     return result;
 }
 
-const Teuchos::ParameterList&  THCM::getParameters()
+const Teuchos::ParameterList& THCM::getParameters()
 { return paramList; }
 
 void THCM::setPreParameters()
@@ -3135,9 +3122,8 @@ void THCM::setPostParameters()
 
 void THCM::setParameters(Teuchos::ParameterList newParams)
 {
-    setDefaultParameters(newParams);
-    newParams.validateParameters(getDefaultParameters());
     paramList.setParameters(newParams);
+    paramList.validateParametersAndSetDefaults(getDefaultInitParameters());
 
     setPreParameters();
     setPostParameters();

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -191,7 +191,7 @@ THCM::THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm)
     DEBUG("### enter THCM::THCM ###");
 
     setDefaultInitParameters(paramList);
-    //FIXME: Validate here when THCM, etc. are done
+    paramList.validateParameters(getDefaultInitParameters());
     setPreParameters();
 
     std::string probdesc = paramList.get<std::string>("Problem Description");
@@ -3131,7 +3131,7 @@ void THCM::setPostParameters()
 void THCM::setParameters(Teuchos::ParameterList newParams)
 {
     setDefaultParameters(newParams);
-    //FIXME: Validate here when THCM, etc. are done
+    newParams.validateParameters(getDefaultParameters());
     paramList.setParameters(newParams);
 
     setPreParameters();

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -3120,10 +3120,15 @@ void THCM::setPreParameters()
 
 void THCM::setPostParameters()
 {
-    double *val = nullptr; //Only used to determine return type of getValue
+    double value; //Only used to determine return type of getValue
     for (const auto& param : paramList.sublist("Starting Parameters")) {
-        if (!std::isnan(param.second.getValue(val))) {
-            this->setParameter(param.first, param.second.getValue(val));
+        if (!std::isnan(param.second.getValue(&value))) {
+            this->setParameter(param.first, param.second.getValue(&value));
+        } else {
+            int p = par2int(param.first);
+            FNAME(getparcs)(&p,&value);
+            paramList.sublist("Starting Parameters").remove(param.first);
+            paramList.sublist("Starting Parameters").get(param.first, value);
         }
     }
 }

--- a/src/ocean/THCM.H
+++ b/src/ocean/THCM.H
@@ -123,13 +123,13 @@ public:
     };
 
     const Teuchos::ParameterList& getParameters();
-    void setParameters(Teuchos::ParameterList);
+    void setParameters(const Teuchos::ParameterList&&);
 
     static Teuchos::ParameterList getDefaultInitParameters();
     static Teuchos::ParameterList getDefaultParameters();
 
     //! Constructor
-    THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm);
+    THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm> comm);
 
     //! Destructor
 
@@ -499,7 +499,7 @@ private:
     Teuchos::RCP<Epetra_MultiVector> nullSpace;
 
     //! global shared parameter list
-    Teuchos::ParameterList paramList;
+    Teuchos::RCP<Teuchos::ParameterList> paramList;
 
     //! timer status list
     Teuchos::ParameterList timerList;

--- a/src/ocean/THCM.H
+++ b/src/ocean/THCM.H
@@ -123,7 +123,7 @@ public:
     };
 
     const Teuchos::ParameterList& getParameters();
-    void setParameters(const Teuchos::ParameterList&&);
+    void setParameters(Teuchos::ParameterList&);
 
     static Teuchos::ParameterList getDefaultInitParameters();
     static Teuchos::ParameterList getDefaultParameters();

--- a/src/ocean/THCM.H
+++ b/src/ocean/THCM.H
@@ -122,6 +122,12 @@ public:
         Teuchos::RCP<Epetra_Vector> dFSdG;
     };
 
+    const Teuchos::ParameterList& getParameters();
+    void setParameters(Teuchos::ParameterList);
+
+    static Teuchos::ParameterList getDefaultInitParameters();
+    static Teuchos::ParameterList getDefaultParameters();
+
     //! Constructor
     THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm);
 
@@ -355,13 +361,13 @@ public:
     //@}
 
     //! obtain a default parameter for a few specific labels
-    double defaultParameter(std::string const &label);
+    static double defaultParameter(std::string const &label);
 
     //! convert parameter name to integer (i.e. "Combined Forcing" => 19)
     int par2int(std::string const &label);
 
     // convert parameter index to std::string (i.e. 19 => "Combined Forcing")
-    std::string const int2par(int ind);
+    static std::string const int2par(int ind);
 
     //! read THCM parameters from a ParameterList
     void ReadParameters(const Teuchos::ParameterList& plist);
@@ -619,6 +625,10 @@ private:
     //! provide a different SolveMap after the call.
     void SetupLoadBalancing();
 
+    void setPreParameters();
+    void setPostParameters();
+    static Teuchos::ParameterList& setDefaultInitParameters(Teuchos::ParameterList&);
+    static Teuchos::ParameterList& setDefaultParameters(Teuchos::ParameterList&);
 };
 
 #endif

--- a/src/ocean/THCM.H
+++ b/src/ocean/THCM.H
@@ -123,7 +123,7 @@ public:
     };
 
     //! Constructor
-    THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm);
+    THCM(const Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm);
 
     //! Destructor
 
@@ -364,7 +364,7 @@ public:
     std::string const int2par(int ind);
 
     //! read THCM parameters from a ParameterList
-    void ReadParameters(Teuchos::ParameterList& plist);
+    void ReadParameters(const Teuchos::ParameterList& plist);
 
     //! Under non-restoring conditions: get an integral from vec and
     //! use that to correct the integral condition

--- a/src/ocean/THCM.H
+++ b/src/ocean/THCM.H
@@ -627,8 +627,6 @@ private:
 
     void setPreParameters();
     void setPostParameters();
-    static Teuchos::ParameterList& setDefaultInitParameters(Teuchos::ParameterList&);
-    static Teuchos::ParameterList& setDefaultParameters(Teuchos::ParameterList&);
 };
 
 #endif

--- a/src/ocean/THCM.H
+++ b/src/ocean/THCM.H
@@ -130,6 +130,7 @@ public:
 
     //! Constructor
     THCM(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<Epetra_Comm> comm);
+    THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm);
 
     //! Destructor
 

--- a/src/tests/intt_2dmoc.C
+++ b/src/tests/intt_2dmoc.C
@@ -19,8 +19,9 @@ TEST(Ocean, Continuation)
     {
         // Create parallel Ocean
         RCP<Teuchos::ParameterList> oceanParams =
-            rcp(new Teuchos::ParameterList);
-        updateParametersFromXmlFile("ocean_params.xml", oceanParams.ptr());
+            Utils::obtainParams("ocean_params.xml", "Ocean parameters");
+        oceanParams->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
         ocean = Teuchos::rcp(new Ocean(comm, oceanParams));
 
         // Create continuation params

--- a/src/tests/intt_coupled.C
+++ b/src/tests/intt_coupled.C
@@ -37,6 +37,9 @@ TEST(ParameterLists, Initialization)
             params.push_back(Utils::obtainParams(files[i], names[i]));
         }
 
+        params[OCEAN]->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
+
         INFO('\n' << "Overwriting:");
         // Allow dominant parameterlists. Not that this trick ignores
         // any hierarchy. The Continuation and CoupledModel

--- a/src/tests/intt_ocean.C
+++ b/src/tests/intt_ocean.C
@@ -15,8 +15,9 @@ TEST(Ocean, Continuation1)
     {
         // Create parallel Ocean
         RCP<Teuchos::ParameterList> oceanParams =
-            rcp(new Teuchos::ParameterList);
-        updateParametersFromXmlFile("ocean_params_intt_init.xml", oceanParams.ptr());
+            Utils::obtainParams("ocean_params_intt_init.xml", "Ocean parameters");
+        oceanParams->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
         ocean = Teuchos::rcp(new Ocean(comm, oceanParams));
 
         // Create continuation params
@@ -78,9 +79,10 @@ TEST(Ocean, Continuation2)
     try
     {
         // Create parallel Ocean
-        RCP<Teuchos::ParameterList> oceanParams =
-            rcp(new Teuchos::ParameterList);
-        updateParametersFromXmlFile("ocean_params_intt_cont.xml", oceanParams.ptr());
+       RCP<Teuchos::ParameterList> oceanParams =
+            Utils::obtainParams("ocean_params_intt_cont.xml", "Ocean parameters");
+        oceanParams->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
         ocean = Teuchos::null;
         ocean = Teuchos::rcp(new Ocean(comm, oceanParams));
 

--- a/src/tests/reft_ocean.C
+++ b/src/tests/reft_ocean.C
@@ -15,8 +15,9 @@ TEST(Ocean, Initialization)
     try
     {
         // Create parallel Ocean
-        oceanParams = rcp(new Teuchos::ParameterList);
-        updateParametersFromXmlFile("reft_ocean_params.xml", oceanParams.ptr());
+        oceanParams = Utils::obtainParams("reft_ocean_params.xml", "Ocean parameters");
+        oceanParams->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
         ocean = Teuchos::rcp(new Ocean(comm, oceanParams));
     }
     catch (...)

--- a/src/tests/test_atmos.C
+++ b/src/tests/test_atmos.C
@@ -413,8 +413,11 @@ TEST(Atmosphere, Reinitialization)
 // this should definitely be factorized
 TEST(Atmosphere, SetMasks)
 {
-    Teuchos::RCP<Teuchos::ParameterList> oceanParams = rcp(new Teuchos::ParameterList);
-    updateParametersFromXmlFile("ocean_params.xml", oceanParams.ptr());
+    Teuchos::RCP<Teuchos::ParameterList> oceanParams =
+        Utils::obtainParams("ocean_params.xml", "Ocean parameters");
+
+    oceanParams->sublist("Belos Solver") =
+        *Utils::obtainParams("solver_params.xml", "Solver parameters");
     Ocean ocean(comm, oceanParams);
 
     Utils::MaskStruct mask = ocean.getLandMask("mask_natl8");

--- a/src/tests/test_coupled.C
+++ b/src/tests/test_coupled.C
@@ -37,6 +37,9 @@ TEST(ParameterLists, Initialization)
         for (int i = 0; i != (int) files.size(); ++i)
             params.push_back(Utils::obtainParams(files[i], names[i]));
 
+        params[OCEAN]->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
+
         INFO('\n' << "Overwriting:");
 
         // Allow dominant parameterlists. Note that this trick uses a

--- a/src/tests/test_integrals.C
+++ b/src/tests/test_integrals.C
@@ -34,6 +34,9 @@ TEST(ParameterLists, Initialization)
         for (int i = 0; i != (int) files.size(); ++i)
             params.push_back(Utils::obtainParams(files[i], names[i]));
 
+        params[OCEAN]->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
+
         INFO('\n' << "Overwriting:");
 
         // Allow dominant parameterlists. Note that this trick uses a

--- a/src/tests/test_jdqz.C
+++ b/src/tests/test_jdqz.C
@@ -26,6 +26,9 @@ public:
             RCP<Teuchos::ParameterList> oceanParams =
                 Utils::obtainParams("ocean_params.xml", "Ocean parameters");
 
+            oceanParams->sublist("Belos Solver") =
+                *Utils::obtainParams("solver_params.xml", "Solver parameters");
+
             // Create parameter object for Atmosphere
             RCP<Teuchos::ParameterList> atmosphereParams =
                 Utils::obtainParams("atmosphere_params.xml", "Atmosphere parameters");

--- a/src/tests/test_matrix.C
+++ b/src/tests/test_matrix.C
@@ -37,6 +37,9 @@ TEST(ParameterLists, Initialization)
         for (int i = 0; i != (int) files.size(); ++i)
             params.push_back(Utils::obtainParams(files[i], names[i]));
 
+        params[OCEAN]->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
+
         INFO('\n' << "Overwriting:");
 
         // Allow dominant parameterlists. Note that this trick uses a

--- a/src/tests/test_ocean.C
+++ b/src/tests/test_ocean.C
@@ -16,8 +16,9 @@ TEST(Ocean, Initialization)
     try
     {
         // Create parallel Ocean
-        oceanParams = rcp(new Teuchos::ParameterList);
-        updateParametersFromXmlFile("ocean_params.xml", oceanParams.ptr());
+        oceanParams = Utils::obtainParams("ocean_params.xml", "Ocean parameters");
+        oceanParams->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
         ocean = Teuchos::rcp(new Ocean(comm, oceanParams));
     }
     catch (...)

--- a/src/tests/test_oceanatmos.C
+++ b/src/tests/test_oceanatmos.C
@@ -33,6 +33,9 @@ TEST(ParameterLists, Initialization)
         for (int i = 0; i != (int) files.size(); ++i)
             params.push_back(Utils::obtainParams(files[i], names[i]));
 
+        params[OCEAN]->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
+
         INFO('\n' << "Overwriting:");
 
         // Allow dominant parameterlists. Note that this trick uses a

--- a/src/tests/test_topo.C
+++ b/src/tests/test_topo.C
@@ -36,8 +36,11 @@ TEST(Topo, Initialization)
 	try
 	{
 		// Create topography class
-		RCP<Teuchos::ParameterList> topoParams = rcp(new Teuchos::ParameterList);
-		updateParametersFromXmlFile("topo_params.xml", topoParams.ptr());
+		RCP<Teuchos::ParameterList> topoParams =
+                    Utils::obtainParams("topo_params.xml", "Topo parameters");
+
+                topoParams->sublist("Belos solver") =
+                    *Utils::obtainParams("solver_params.xml", "Solver parameters");
 		topo = rcp(new Topo<RCP<Ocean>, RCP<Teuchos::ParameterList> >
 				   (ocean, topoParams));
 	}

--- a/src/tests/test_topo.C
+++ b/src/tests/test_topo.C
@@ -16,8 +16,9 @@ TEST(Ocean, Initialization)
 	{
 		// Create parallel Ocean
 		RCP<Teuchos::ParameterList> oceanParams =
-			rcp(new Teuchos::ParameterList);
-		updateParametersFromXmlFile("ocean_params.xml", oceanParams.ptr());
+			Utils::obtainParams("ocean_params.xml", "Ocean parameters");
+		oceanParams->sublist("Belos Solver") =
+			*Utils::obtainParams("solver_params.xml", "Solver parameters");
 		ocean = Teuchos::rcp(new Ocean(comm, oceanParams));
 	}
 	catch (...)

--- a/src/tests/trns_ocean.C
+++ b/src/tests/trns_ocean.C
@@ -25,6 +25,9 @@ TEST(ParameterLists, Initialization)
 
         for (int i = 0; i != (int) files.size(); ++i)
             params.push_back(Utils::obtainParams(files[i], names[i]));
+
+        params[OCEAN]->sublist("Belos Solver") =
+            *Utils::obtainParams("solver_params.xml", "Solver parameters");
     }
     catch (...)
     {

--- a/src/topo/Topo.H
+++ b/src/topo/Topo.H
@@ -518,8 +518,6 @@ void Topo<Model, ParameterList>::initializeSolver()
         return;
 
     INFO("Topo: initialize solver...");
-    solverParams_ = rcp(new Teuchos::ParameterList);
-    updateParametersFromXmlFile("solver_params.xml", solverParams_.ptr());
 
     // Belos LinearProblem setup
     Teuchos::RCP<Combined_Operator<Model> > combMatPtr =
@@ -537,39 +535,40 @@ void Topo<Model, ParameterList>::initializeSolver()
 
     problem_->setRightPrec(combPrecPtr);
 
+    Teuchos::ParameterList& solverParams = pars_->sublist("Belos solver");
     // A few FGMRES parameters are made available in solver_params.xml:
-    int gmresIters  = solverParams_->get("Topo FGMRES iterations", 400);
-    double gmresTol = solverParams_->get("Topo FGMRES tolerance", 1e-2);
-    int maxrestarts = solverParams_->get("Topo FGMRES restarts", 2);
-    int output      = solverParams_->get("Topo FGMRES output", 20);
+    int gmresIters  = solverParams.get("FGMRES iterations", 400);
+    double gmresTol = solverParams.get("FGMRES tolerance", 1e-2);
+    int maxrestarts = solverParams.get("FGMRES restarts", 2);
+    int output      = solverParams.get("FGMRES output", 20);
 
     int NumGlobalElements = stateView_->GlobalLength();
     int blocksize         = 1; // number of vectors in rhs
     int maxiters          = NumGlobalElements / blocksize - 1;
 
     // Create Belos parameterlist
-    belosParamList_ = rcp(new Teuchos::ParameterList());
-    belosParamList_->set("Block Size", blocksize);
-    belosParamList_->set("Flexible Gmres", true);
-    belosParamList_->set("Adaptive Block Size", true);
-    belosParamList_->set("Num Blocks", gmresIters);
-    belosParamList_->set("Maximum Restarts", maxrestarts);
-    belosParamList_->set("Orthogonalization","DGKS");
-    belosParamList_->set("Output Frequency", output);
-    belosParamList_->set("Verbosity", Belos::TimingDetails +
+    RCP<Teuchos::ParameterList> belosParamList = rcp(new Teuchos::ParameterList());
+    belosParamList->set("Block Size", blocksize);
+    belosParamList->set("Flexible Gmres", true);
+    belosParamList->set("Adaptive Block Size", true);
+    belosParamList->set("Num Blocks", gmresIters);
+    belosParamList->set("Maximum Restarts", maxrestarts);
+    belosParamList->set("Orthogonalization","DGKS");
+    belosParamList->set("Output Frequency", output);
+    belosParamList->set("Verbosity", Belos::TimingDetails +
                          Belos::Errors +
                          Belos::Warnings +
                          Belos::StatusTestDetails );
-    belosParamList_->set("Maximum Iterations", maxiters);
-    belosParamList_->set("Convergence Tolerance", gmresTol);
-    belosParamList_->set("Explicit Residual Test", false);
-    belosParamList_->set("Implicit Residual Scaling", "Norm of RHS");
+    belosParamList->set("Maximum Iterations", maxiters);
+    belosParamList->set("Convergence Tolerance", gmresTol);
+    belosParamList->set("Explicit Residual Test", false);
+    belosParamList->set("Implicit Residual Scaling", "Norm of RHS");
 
     // Belos block FGMRES setup
     belosSolver_ =
         rcp(new Belos::BlockGmresSolMgr
             <double, Epetra_MultiVector, Combined_Operator<Model> >
-            (problem_, belosParamList_));
+            (problem_, belosParamList));
 
     solverInitialized_ = true;
     INFO("Topo: initialize solver... done");

--- a/src/topo/TopoDecl.H
+++ b/src/topo/TopoDecl.H
@@ -139,9 +139,6 @@ private:
 	//! If every converged state deserves to be stored, enable this
 	int saveEvery_;
 
-	//! Solver parameterlist
-	ParameterList solverParams_, belosParamList_;
-
 	Teuchos::RCP
 	<Belos::LinearProblem
 	 <double, Epetra_MultiVector, Combined_Operator<Model> > > problem_;	

--- a/test/atmos/ocean_params.xml
+++ b/test/atmos/ocean_params.xml
@@ -95,9 +95,6 @@
     <!-- Hack!  -->
     <Parameter name="Local SRES Only" type="bool" value="false"/>
     
-    <!-- Freshwater Forcing (ifw in THCM) -->
-    <!-- 0: data, 1: idealized            -->
-    <Parameter name="Freshwater Forcing" type="int" value="1"/>
     <!-- Temperature forcing                                 -->
     <!-- Levitus Temperature (ite in THCM)                   -->
     <!-- 0: data, 1: idealized                               -->

--- a/test/coupled/ocean_params.xml
+++ b/test/coupled/ocean_params.xml
@@ -14,10 +14,6 @@
   <Parameter name="Input file"  type="string" value="ocean_input.h5" />
   <Parameter name="Output file" type="string" value="ocean_output.h5" />
 
-  <!-- To keep track of each converged state, enable this.    -->
-  <!-- Only useful when you enable <Save state>               -->
-  <Parameter name="Save every step" type="bool" value="false" />
-
   <!-- Parameters that affect THCM { -->
   <ParameterList name="THCM">
     <!-- a descriptive name to identify the settings -->

--- a/test/jdqz/ocean_params.xml
+++ b/test/jdqz/ocean_params.xml
@@ -98,6 +98,11 @@
     <!-- Levitus Salt (its in THCM) -->
     <!-- 0: data, 1: idealized             -->
     <Parameter name="Levitus S" type="int" value="1"/>
+    <!-- Wind Forcing (iza in THCM)       -->
+    <!-- 0: data,                         -->
+    <!-- 1: zonally averaged              -->
+    <!-- 2: idealized                     -->
+    <Parameter name="Wind Forcing Type" type="int" value="2"/>
     <!-- Type of scaling applied to the linear systems.         -->
     <!-- We currently support "None" and "THCM"                 -->
     <!-- "None" is not really recomended.                       -->

--- a/test/jdqz/ocean_params.xml
+++ b/test/jdqz/ocean_params.xml
@@ -91,9 +91,6 @@
     <!-- 0: non-restoring                             -->
     <!-- 1: restoring                                 -->
     <Parameter name="Restoring Salinity Profile" type="int" value="0"/>
-    <!-- Freshwater Forcing (ifw in THCM) -->
-    <!-- 0: data, 1: idealized            -->
-    <Parameter name="Freshwater Forcing" type="int" value="1"/>
     <!-- Temperature forcing                                 -->
     <!-- Levitus Temperature (ite in THCM)                   -->
     <!-- 0: data, 1: idealized                               -->
@@ -101,11 +98,6 @@
     <!-- Levitus Salt (its in THCM) -->
     <!-- 0: data, 1: idealized             -->
     <Parameter name="Levitus S" type="int" value="1"/>
-    <!-- Wind Forcing (iza in THCM)       -->
-    <!-- 0: data,                         -->
-    <!-- 1: zonally averaged              -->
-    <!-- 2: idealized                     -->
-    <Parameter name="Wind Forcing" type="int" value="2"/>
     <!-- Type of scaling applied to the linear systems.         -->
     <!-- We currently support "None" and "THCM"                 -->
     <!-- "None" is not really recomended.                       -->

--- a/test/matrix/ocean_params.xml
+++ b/test/matrix/ocean_params.xml
@@ -14,10 +14,6 @@
   <Parameter name="Input file"  type="string" value="ocean_input.h5" />
   <Parameter name="Output file" type="string" value="ocean_output.h5" />
 
-  <!-- To keep track of each converged state, enable this.    -->
-  <!-- Only useful when you enable <Save state>               -->
-  <Parameter name="Save every step" type="bool" value="false" />
-
   <!-- Parameters that affect THCM { -->
   <ParameterList name="THCM">
     <!-- a descriptive name to identify the settings -->

--- a/test/ocean/ocean_params.xml
+++ b/test/ocean/ocean_params.xml
@@ -95,9 +95,6 @@
     <!-- Hack!  -->
     <Parameter name="Local SRES Only" type="bool" value="false"/>
     
-    <!-- Freshwater Forcing (ifw in THCM) -->
-    <!-- 0: data, 1: idealized            -->
-    <Parameter name="Freshwater Forcing" type="int" value="1"/>
     <!-- Temperature forcing                                 -->
     <!-- Levitus Temperature (ite in THCM)                   -->
     <!-- 0: data, 1: idealized                               -->

--- a/test/ocean/ocean_params_intt_cont.xml
+++ b/test/ocean/ocean_params_intt_cont.xml
@@ -10,8 +10,6 @@
   <Parameter name="Load salinity flux"    type="bool" value="true"/>
   <Parameter name="Load temperature flux" type="bool" value="false"/>
 
-  <Parameter name="Compute column integral" type="bool" value="true"/>      
-  
   <!-- Parameters that affect THCM { -->
   <ParameterList name="THCM">
     <!-- a descriptive name to identify the settings -->
@@ -94,9 +92,6 @@
          positive or a negative sign. Negative is the default. -->
     <Parameter name="Salinity Integral Sign" type="int" value="+1"/>
     
-    <!-- Freshwater Forcing (ifw in THCM) -->
-    <!-- 0: data, 1: idealized            -->
-    <Parameter name="Freshwater Forcing" type="int" value="1"/>
     <!-- Temperature forcing                                 -->
     <!-- Levitus Temperature (ite in THCM)                   -->
     <!-- 0: data, 1: idealized                               -->

--- a/test/ocean/ocean_params_intt_init.xml
+++ b/test/ocean/ocean_params_intt_init.xml
@@ -86,9 +86,6 @@
     <!-- 0: non-restoring                             -->
     <!-- 1: restoring                                 -->
     <Parameter name="Restoring Salinity Profile" type="int" value="1"/>
-    <!-- Freshwater Forcing (ifw in THCM) -->
-    <!-- 0: data, 1: idealized            -->
-    <Parameter name="Freshwater Forcing" type="int" value="1"/>
     <!-- Temperature forcing                                 -->
     <!-- Levitus Temperature (ite in THCM)                   -->
     <!-- 0: data, 1: idealized                               -->

--- a/test/ocean/reft_ocean_params.xml
+++ b/test/ocean/reft_ocean_params.xml
@@ -6,7 +6,6 @@
 <ParameterList name="Ocean">
 
   <Parameter name="Load state" type="bool" value="false"/>
-  <Parameter name="Use legacy fortran output" type="bool" value="false"/>
   
   <!-- Parameters that affect THCM { -->
   <ParameterList name="THCM">
@@ -92,9 +91,6 @@
     <!-- 1: restoring                                 -->
     <Parameter name="Restoring Salinity Profile" type="int" value="1"/>
     
-    <!-- Freshwater Forcing (ifw in THCM) -->
-    <!-- 0: data, 1: idealized            -->
-    <Parameter name="Freshwater Forcing" type="int" value="1"/>
     <!-- Temperature forcing                                 -->
     <!-- Levitus Temperature (ite in THCM)                   -->
     <!-- 0: data, 1: idealized                               -->

--- a/test/ocean/test_oceantransient.xml
+++ b/test/ocean/test_oceantransient.xml
@@ -95,9 +95,6 @@
     <!-- Hack!  -->
     <Parameter name="Local SRES Only" type="bool" value="false"/>
     
-    <!-- Freshwater Forcing (ifw in THCM) -->
-    <!-- 0: data, 1: idealized            -->
-    <Parameter name="Freshwater Forcing" type="int" value="1"/>
     <!-- Temperature forcing                                 -->
     <!-- Levitus Temperature (ite in THCM)                   -->
     <!-- 0: data, 1: idealized                               -->

--- a/test/oceanatmos/test_oa_ocean.xml
+++ b/test/oceanatmos/test_oa_ocean.xml
@@ -14,10 +14,6 @@
   <Parameter name="Input file"  type="string" value="ocean_input.h5" />
   <Parameter name="Output file" type="string" value="ocean_output.h5" />
 
-  <!-- To keep track of each converged state, enable this.    -->
-  <!-- Only useful when you enable <Save state>               -->
-  <Parameter name="Save every step" type="bool" value="false" />
-
   <!-- Parameters that affect THCM { -->
   <ParameterList name="THCM">
     <!-- a descriptive name to identify the settings -->

--- a/test/topo/ocean_params.xml
+++ b/test/topo/ocean_params.xml
@@ -86,6 +86,11 @@
     <!-- Levitus Salt (its in THCM) -->
     <!-- 0: data, 1: idealized             -->
     <Parameter name="Levitus S" type="int" value="1"/>
+    <!-- Wind Forcing (iza in THCM)       -->
+    <!-- 0: data,                         -->
+    <!-- 1: zonally averaged              -->
+    <!-- 2: idealized                     -->
+    <Parameter name="Wind Forcing Type" type="int" value="2"/>
     <!-- Type of scaling applied to the linear systems.         -->
     <!-- We currently support "None" and "THCM"                 -->
     <!-- "None" is not really recomended.                       -->

--- a/test/topo/ocean_params.xml
+++ b/test/topo/ocean_params.xml
@@ -79,9 +79,6 @@
     <!-- 0: non-restoring                             -->
     <!-- 1: restoring                                 -->
     <Parameter name="Restoring Salinity Profile" type="int" value="1"/>
-    <!-- Freshwater Forcing (ifw in THCM) -->
-    <!-- 0: data, 1: idealized            -->
-    <Parameter name="Freshwater Forcing" type="int" value="1"/>
     <!-- Temperature forcing                                 -->
     <!-- Levitus Temperature (ite in THCM)                   -->
     <!-- 0: data, 1: idealized                               -->
@@ -89,11 +86,6 @@
     <!-- Levitus Salt (its in THCM) -->
     <!-- 0: data, 1: idealized             -->
     <Parameter name="Levitus S" type="int" value="1"/>
-    <!-- Wind Forcing (iza in THCM)       -->
-    <!-- 0: data,                         -->
-    <!-- 1: zonally averaged              -->
-    <!-- 2: idealized                     -->
-    <Parameter name="Wind Forcing" type="int" value="2"/>
     <!-- Type of scaling applied to the linear systems.         -->
     <!-- We currently support "None" and "THCM"                 -->
     <!-- "None" is not really recomended.                       -->

--- a/test/topo/solver_params.xml
+++ b/test/topo/solver_params.xml
@@ -12,13 +12,4 @@
   <Parameter name="FGMRES iterations" type="int" value="100"/>
   <Parameter name="FGMRES restarts" type="int" value="0"/>
   <Parameter name="FGMRES output" type="int" value="1000"/> <!-- Output Frequency -->
-
-  <!-- ..................................................................-->
-  <!-- FGMRES (Belos) parameters for topo homotopy continuation          -->  
-  <!-- ..................................................................-->
-  <Parameter name="Topo FGMRES tolerance" type="double" value="1e-2"/>
-  <Parameter name="Topo FGMRES iterations" type="int" value="100"/>
-  <Parameter name="Topo FGMRES restarts" type="int" value="0"/>
-  <Parameter name="Topo FGMRES output" type="int" value="1000"/>
-
 </ParameterList>


### PR DESCRIPTION
Doesn't currently include validation because THCM parameters are passed via ocean and don't pass validation.

I think the best approach is to refactor THCM in a similar fashion so that Ocean can simply query the default parameters from THCM and extend its default parameters with those. The main obstacle is that some of THCM's parameters are only used in the constructor, so it's unclear what "setting" those would mean/look like. Specifically THCM parameters only used in the constructor to initialise other values are:

```
double qz      = paramList.get("Grid Stretching qz", 1.0);
int    itopo   = paramList.get("Topography", 1);
bool   flat    = paramList.get("Flat Bottom", false);
bool   rd_mask = paramList.get("Read Land Mask", false); //== false in experiment0
bool rd_spertm     = paramList.get("Read Salinity Perturbation Mask",false);
int coriolis_on    = paramList.get("Coriolis Force", 1);
int forcing_type   = paramList.get("Forcing Type", 0);
std::string spertm_file = paramList.get("Salinity Perturbation Mask", "no_mask_specified");
std::string windf_file = paramList.get("Wind Forcing Data", "wind/trtau.dat");

// Let THCM know the sst forcing file
std::string sst_file = paramList.get("Temperature Forcing Data", "levitus/new/t00an1");

// Let THCM know the sss forcing file
std::string sss_file = paramList.get("Salinity Forcing Data", "levitus/new/s00an1");

bool time_dep_forcing = paramList.get("Time Dependent Forcing",false);
int Nic = paramList.get("Integral row coordinate i", N-1);
int Mic = paramList.get("Integral row coordinate j", M-1);
```

@erik808 @Sbte what do you think should be done with those parameters?