### PR TITLE
Eliminate unused setParameters from Ocean.

### DIFF
--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -2198,29 +2198,3 @@ void Ocean::setPar(std::string const &parName, double value)
     if (parIdent > 0 && parIdent <= _NPAR_)
         FNAME(setparcs)(&parIdent, &value);
 }
-
-//====================================================================
-void Ocean::setParameters(ParameterList pars)
-{
-    std::string parName;
-    double parValue;
-    // This is similar to reading from HDF5
-    for (int par = 1; par <= _NPAR_; ++par)
-    {
-        parName  = THCM::Instance().int2par(par);
-        parValue = getPar(parName);
-
-        // Overwrite continuation parameter and put it in THCM
-        try
-        {
-            parValue = pars->get(parName, parValue);
-        }
-        catch (EpetraExt::Exception &e)
-        {
-            e.Print();
-            continue;
-        }
-
-        setPar(parName, parValue);
-    }
-}

--- a/src/ocean/Ocean.H
+++ b/src/ocean/Ocean.H
@@ -381,8 +381,6 @@ public:
     VectorPtr getRowScaling();
     VectorPtr getColScaling();
 
-    void setParameters(ParameterList pars);
-
     void copyMask(std::string const &fname);
 
     void dumpBlocks()


### PR DESCRIPTION
This frees up the name to use as consistent interface for setting/updating
ParameterList.