### PR TITLE
THCM: Remove some variables from the global module

### DIFF
--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -58,6 +58,7 @@ extern "C" {
     _SUBROUTINE_(init)(int* n, int* m, int* l, int* nmlglob,
                        double* xmin, double* xmax, double* ymin, double* ymax,
                        double* alphaT, double* alphaS,
+                       int* ih,
                        int* periodic, int* landm,
                        double* taux, double* tauy, double* tatm, double* emip, double* spert);
 
@@ -70,7 +71,7 @@ extern "C" {
                                              double* Xmin, double* Xmax,
                                              double* Ymin, double* Ymax,
                                              double* hdim, double* qz,
-                                             int* ih,int* vmix_GLB, int* tap, int* rho_mixing,
+                                             int* vmix_GLB, int* tap, int* rho_mixing,
                                              int* periodic, int* itopo, int* flat, int* rd_mask,
                                              int* TRES, int* SRES, int* iza, int* ite ,int* its, int* rd_spertm,
                                              int* coupled_T, int* coupled_S, int* coriolis_on,
@@ -358,7 +359,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     //  __m_global_MOD_initialize
     F90NAME(m_global, initialize)(&nglob_, &mglob_, &lglob_,
                                   &xmin, &xmax, &ymin, &ymax, &hdim, &qz,
-                                  &ih, &vmixGLB_, &tap, &irho_mixing,
+                                  &vmixGLB_, &tap, &irho_mixing,
                                   &iperiodic, &itopo, &iflat, &ird_mask,
                                   &tres_, &sres_, &iza, &ite_, &its_, &ird_spertm,
                                   &coupledT_, &coupledS_, &coriolis_on,
@@ -607,6 +608,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     FNAME(init)(&nloc, &mloc, &lloc, &nmlglob,
                 &xminloc, &xmaxloc, &yminloc, &ymaxloc,
                 &alphaT,&alphaS,
+                &ih,
                 &perio, landm,
                 taux, tauy, tatm, emip, spert);
 

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -58,7 +58,7 @@ extern "C" {
     _SUBROUTINE_(init)(int* n, int* m, int* l, int* nmlglob,
                        double* xmin, double* xmax, double* ymin, double* ymax,
                        double* alphaT, double* alphaS,
-                       int* ih,
+                       int* ih, int* vmix,
                        int* periodic, int* landm,
                        double* taux, double* tauy, double* tatm, double* emip, double* spert);
 
@@ -71,7 +71,7 @@ extern "C" {
                                              double* Xmin, double* Xmax,
                                              double* Ymin, double* Ymax,
                                              double* hdim, double* qz,
-                                             int* vmix_GLB, int* tap, int* rho_mixing,
+                                             int* tap, int* rho_mixing,
                                              int* periodic, int* itopo, int* flat, int* rd_mask,
                                              int* TRES, int* SRES, int* iza, int* ite ,int* its, int* rd_spertm,
                                              int* coupled_T, int* coupled_S, int* coriolis_on,
@@ -359,7 +359,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     //  __m_global_MOD_initialize
     F90NAME(m_global, initialize)(&nglob_, &mglob_, &lglob_,
                                   &xmin, &xmax, &ymin, &ymax, &hdim, &qz,
-                                  &vmixGLB_, &tap, &irho_mixing,
+                                  &tap, &irho_mixing,
                                   &iperiodic, &itopo, &iflat, &ird_mask,
                                   &tres_, &sres_, &iza, &ite_, &its_, &ird_spertm,
                                   &coupledT_, &coupledS_, &coriolis_on,
@@ -608,7 +608,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     FNAME(init)(&nloc, &mloc, &lloc, &nmlglob,
                 &xminloc, &xmaxloc, &yminloc, &ymaxloc,
                 &alphaT,&alphaS,
-                &ih,
+                &ih, &vmixGLB_,
                 &perio, landm,
                 taux, tauy, tatm, emip, spert);
 

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -47,50 +47,39 @@
 extern "C" {
 
     // usrc.F90
-    _SUBROUTINE_(setparcs)(int*,double*);
-    _SUBROUTINE_(getparcs)(int*,double*);
+    _SUBROUTINE_(setparcs)(int* param, double* value);
+    _SUBROUTINE_(getparcs)(int* param, double* value);
     _SUBROUTINE_(writeparams)();
-    _SUBROUTINE_(rhs)(double*,double*);
-    _SUBROUTINE_(setsres)(int *);
-    _SUBROUTINE_(matrix)(double*);
+    _SUBROUTINE_(rhs)(double* un, double* b);
+    _SUBROUTINE_(setsres)(int* sres);
+    _SUBROUTINE_(matrix)(double* un);
     _SUBROUTINE_(stochastic_forcing)();
 
-    // input:   n,m,l,nmlglob
-    //          xmin,xmax,ymin,ymax,
-    //          alphaT,alphaS,
-    //          periodic,landm,
-    //          taux,tauy,tatm,emip,spert
-    _SUBROUTINE_(init)(int*,int*,int*,int*,
-                       double*,double*,double*,double*,
-                       double*,double*,
-                       int*,int*,
-                       double*,double*,double*,double*,double*);
+    _SUBROUTINE_(init)(int* n, int* m, int* l, int* nmlglob,
+                       double* xmin, double* xmax, double* ymin, double* ymax,
+                       double* alphaT, double* alphaS,
+                       int* periodic, int* landm,
+                       double* taux, double* tauy, double* tatm, double* emip, double* spert);
 
-    // input:   landm
-    _SUBROUTINE_(set_landmask)(int *, int *, int *);
+    _SUBROUTINE_(set_landmask)(int* landm, int* periodic, int* reinit);
 
     _SUBROUTINE_(finalize)(void);
 
     // global.F90
-    // input:   N,M,L,
-    //          Xmin,Xmax,Ymin,Ymax,hdim,qz,
-    //          ih,vmix_GLB,tap,rho_mixing,
-    //          periodic,itopo,flat,rd_mask,
-    //          TRES,SRES,iza,ite_,its_,rd_spertm
-    //          coupledT_, coupledS_, coriolis_on,
-    //          forcing_type
-    _MODULE_SUBROUTINE_(m_global,initialize)(int*,int*,int*,
-                                             double*,double*,double*,double*,double*,double*,
-                                             int*,int*,int*,int*,
-                                             int*,int*,int*,int*,
-                                             int*,int*,int*,int*,int*,int*,
-                                             int*,int*,int*,
-                                             int*);
+    _MODULE_SUBROUTINE_(m_global,initialize)(int* N, int* M, int* L,
+                                             double* Xmin, double* Xmax,
+                                             double* Ymin, double* Ymax,
+                                             double* hdim, double* qz,
+                                             int* ih,int* vmix_GLB, int* tap, int* rho_mixing,
+                                             int* periodic, int* itopo, int* flat, int* rd_mask,
+                                             int* TRES, int* SRES, int* iza, int* ite ,int* its, int* rd_spertm,
+                                             int* coupled_T, int* coupled_S, int* coriolis_on,
+                                             int* forcing_type);
 
     _MODULE_SUBROUTINE_(m_global,finalize)(void);
-    _MODULE_SUBROUTINE_(m_global,get_landm)(int*);
-    _MODULE_SUBROUTINE_(m_global,get_current_landm)(int*);
-    _MODULE_SUBROUTINE_(m_global,set_landm)(int*);
+    _MODULE_SUBROUTINE_(m_global,get_landm)(int* landm);
+    _MODULE_SUBROUTINE_(m_global,get_current_landm)(int* landm);
+    _MODULE_SUBROUTINE_(m_global,set_landm)(int* landm);
     _MODULE_SUBROUTINE_(m_global,get_monthly_forcing)(double* tatm, double* emip,
                                                       double* taux, double* tauy, int* month);
     _MODULE_SUBROUTINE_(m_global,get_monthly_internal_forcing)(double* temp, double* salt,

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -58,7 +58,7 @@ extern "C" {
     _SUBROUTINE_(init)(int* n, int* m, int* l, int* nmlglob,
                        double* xmin, double* xmax, double* ymin, double* ymax,
                        double* alphaT, double* alphaS,
-                       int* ih, int* vmix, int* tap,
+                       int* ih, int* vmix, int* tap, int* rho_mixing,
                        int* periodic, int* landm,
                        double* taux, double* tauy, double* tatm, double* emip, double* spert);
 
@@ -71,7 +71,6 @@ extern "C" {
                                              double* Xmin, double* Xmax,
                                              double* Ymin, double* Ymax,
                                              double* hdim, double* qz,
-                                             int* rho_mixing,
                                              int* periodic, int* itopo, int* flat, int* rd_mask,
                                              int* TRES, int* SRES, int* iza, int* ite ,int* its, int* rd_spertm,
                                              int* coupled_T, int* coupled_S, int* coriolis_on,
@@ -359,7 +358,6 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     //  __m_global_MOD_initialize
     F90NAME(m_global, initialize)(&nglob_, &mglob_, &lglob_,
                                   &xmin, &xmax, &ymin, &ymax, &hdim, &qz,
-                                  &irho_mixing,
                                   &iperiodic, &itopo, &iflat, &ird_mask,
                                   &tres_, &sres_, &iza, &ite_, &its_, &ird_spertm,
                                   &coupledT_, &coupledS_, &coriolis_on,
@@ -608,7 +606,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     FNAME(init)(&nloc, &mloc, &lloc, &nmlglob,
                 &xminloc, &xmaxloc, &yminloc, &ymaxloc,
                 &alphaT,&alphaS,
-                &ih, &vmix_, &tap,
+                &ih, &vmix_, &tap, &irho_mixing,
                 &perio, landm,
                 taux, tauy, tatm, emip, spert);
 

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -57,12 +57,12 @@ extern "C" {
 
     // input:   n,m,l,nmlglob
     //          xmin,xmax,ymin,ymax,
-    //          alphaT,
+    //          alphaT,alphaS,
     //          periodic,landm,
     //          taux,tauy,tatm,emip,spert
     _SUBROUTINE_(init)(int*,int*,int*,int*,
                        double*,double*,double*,double*,
-                       double*,
+                       double*,double*,
                        int*,int*,
                        double*,double*,double*,double*,double*);
 
@@ -74,7 +74,6 @@ extern "C" {
     // global.F90
     // input:   N,M,L,
     //          Xmin,Xmax,Ymin,Ymax,hdim,qz,
-    //          alphaS,
     //          ih,vmix_GLB,tap,rho_mixing,
     //          periodic,itopo,flat,rd_mask,
     //          TRES,SRES,iza,ite_,its_,rd_spertm
@@ -82,7 +81,6 @@ extern "C" {
     //          forcing_type
     _MODULE_SUBROUTINE_(m_global,initialize)(int*,int*,int*,
                                              double*,double*,double*,double*,double*,double*,
-                                             double*,
                                              int*,int*,int*,int*,
                                              int*,int*,int*,int*,
                                              int*,int*,int*,int*,int*,int*,
@@ -371,7 +369,6 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     //  __m_global_MOD_initialize
     F90NAME(m_global, initialize)(&nglob_, &mglob_, &lglob_,
                                   &xmin, &xmax, &ymin, &ymax, &hdim, &qz,
-                                  &alphaS,
                                   &ih, &vmixGLB_, &tap, &irho_mixing,
                                   &iperiodic, &itopo, &iflat, &ird_mask,
                                   &tres_, &sres_, &iza, &ite_, &its_, &ird_spertm,
@@ -620,7 +617,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     DEBUG("call init..."); // in usrc.F90
     FNAME(init)(&nloc, &mloc, &lloc, &nmlglob,
                 &xminloc, &xmaxloc, &yminloc, &ymaxloc,
-                &alphaT,
+                &alphaT,&alphaS,
                 &perio, landm,
                 taux, tauy, tatm, emip, spert);
 

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -59,6 +59,7 @@ extern "C" {
                        double* xmin, double* xmax, double* ymin, double* ymax,
                        double* alphaT, double* alphaS,
                        int* ih, int* vmix, int* tap, int* rho_mixing,
+                       int* coriolis_on,
                        int* periodic, int* landm,
                        double* taux, double* tauy, double* tatm, double* emip, double* spert);
 
@@ -73,7 +74,7 @@ extern "C" {
                                              double* hdim, double* qz,
                                              int* periodic, int* itopo, int* flat, int* rd_mask,
                                              int* TRES, int* SRES, int* iza, int* ite ,int* its, int* rd_spertm,
-                                             int* coupled_T, int* coupled_S, int* coriolis_on,
+                                             int* coupled_T, int* coupled_S,
                                              int* forcing_type);
 
     _MODULE_SUBROUTINE_(m_global,finalize)(void);
@@ -360,7 +361,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
                                   &xmin, &xmax, &ymin, &ymax, &hdim, &qz,
                                   &iperiodic, &itopo, &iflat, &ird_mask,
                                   &tres_, &sres_, &iza, &ite_, &its_, &ird_spertm,
-                                  &coupledT_, &coupledS_, &coriolis_on,
+                                  &coupledT_, &coupledS_,
                                   &forcing_type);
 
     INFO("THCM init: m_global::initialize... done");
@@ -607,6 +608,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
                 &xminloc, &xmaxloc, &yminloc, &ymaxloc,
                 &alphaT,&alphaS,
                 &ih, &vmix_, &tap, &irho_mixing,
+                &coriolis_on,
                 &perio, landm,
                 taux, tauy, tatm, emip, spert);
 

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -57,10 +57,12 @@ extern "C" {
 
     // input:   n,m,l,nmlglob
     //          xmin,xmax,ymin,ymax,
+    //          alphaT,
     //          periodic,landm,
     //          taux,tauy,tatm,emip,spert
     _SUBROUTINE_(init)(int*,int*,int*,int*,
                        double*,double*,double*,double*,
+                       double*,
                        int*,int*,
                        double*,double*,double*,double*,double*);
 
@@ -72,7 +74,7 @@ extern "C" {
     // global.F90
     // input:   N,M,L,
     //          Xmin,Xmax,Ymin,Ymax,hdim,qz,
-    //          alphaT,alphaS,
+    //          alphaS,
     //          ih,vmix_GLB,tap,rho_mixing,
     //          periodic,itopo,flat,rd_mask,
     //          TRES,SRES,iza,ite_,its_,rd_spertm
@@ -80,7 +82,7 @@ extern "C" {
     //          forcing_type
     _MODULE_SUBROUTINE_(m_global,initialize)(int*,int*,int*,
                                              double*,double*,double*,double*,double*,double*,
-                                             double*,double*,
+                                             double*,
                                              int*,int*,int*,int*,
                                              int*,int*,int*,int*,
                                              int*,int*,int*,int*,int*,int*,
@@ -369,7 +371,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     //  __m_global_MOD_initialize
     F90NAME(m_global, initialize)(&nglob_, &mglob_, &lglob_,
                                   &xmin, &xmax, &ymin, &ymax, &hdim, &qz,
-                                  &alphaT, &alphaS,
+                                  &alphaS,
                                   &ih, &vmixGLB_, &tap, &irho_mixing,
                                   &iperiodic, &itopo, &iflat, &ird_mask,
                                   &tres_, &sres_, &iza, &ite_, &its_, &ird_spertm,
@@ -618,6 +620,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     DEBUG("call init..."); // in usrc.F90
     FNAME(init)(&nloc, &mloc, &lloc, &nmlglob,
                 &xminloc, &xmaxloc, &yminloc, &ymaxloc,
+                &alphaT,
                 &perio, landm,
                 taux, tauy, tatm, emip, spert);
 

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -231,7 +231,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     }
 
     int ih             = paramList_.get<int>("Inhomogeneous Mixing");
-    vmixGLB_           = paramList_.get<int>("Mixing");
+    vmix_              = paramList_.get<int>("Mixing");
     bool rho_mixing    = paramList_.get<bool>("Rho Mixing");
     int tap            = paramList_.get<int>("Taper");
     double alphaT      = paramList_.get<double>("Linear EOS: alpha T");
@@ -353,7 +353,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     int ird_spertm  = (rd_spertm ) ? 1 : 0;
 
     INFO("THCM init: m_global::initialize...");
-    INFO("    Mixing: vmix_GLB = " << vmixGLB_);
+    INFO("    Mixing: vmix = " << vmix_);
 
     // In fortran object code this corresponds to the function
     //  __m_global_MOD_initialize
@@ -608,7 +608,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     FNAME(init)(&nloc, &mloc, &lloc, &nmlglob,
                 &xminloc, &xmaxloc, &yminloc, &ymaxloc,
                 &alphaT,&alphaS,
-                &ih, &vmixGLB_,
+                &ih, &vmix_,
                 &perio, landm,
                 taux, tauy, tatm, emip, spert);
 
@@ -2609,7 +2609,7 @@ Teuchos::RCP<Epetra_Vector> THCM::getIntCondCoeff()
 // set vmix_fix
 void THCM::fixMixing(int value)
 {
-    if (vmixGLB_ == 2)
+    if (vmix_ == 2)
     {
         INFO(" ** fixing vmix_fix: " << value << " **");
         F90NAME(m_mix, set_vmix_fix)(&value);

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -58,7 +58,7 @@ extern "C" {
     _SUBROUTINE_(init)(int* n, int* m, int* l, int* nmlglob,
                        double* xmin, double* xmax, double* ymin, double* ymax,
                        double* alphaT, double* alphaS,
-                       int* ih, int* vmix,
+                       int* ih, int* vmix, int* tap,
                        int* periodic, int* landm,
                        double* taux, double* tauy, double* tatm, double* emip, double* spert);
 
@@ -71,7 +71,7 @@ extern "C" {
                                              double* Xmin, double* Xmax,
                                              double* Ymin, double* Ymax,
                                              double* hdim, double* qz,
-                                             int* tap, int* rho_mixing,
+                                             int* rho_mixing,
                                              int* periodic, int* itopo, int* flat, int* rd_mask,
                                              int* TRES, int* SRES, int* iza, int* ite ,int* its, int* rd_spertm,
                                              int* coupled_T, int* coupled_S, int* coriolis_on,
@@ -359,7 +359,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     //  __m_global_MOD_initialize
     F90NAME(m_global, initialize)(&nglob_, &mglob_, &lglob_,
                                   &xmin, &xmax, &ymin, &ymax, &hdim, &qz,
-                                  &tap, &irho_mixing,
+                                  &irho_mixing,
                                   &iperiodic, &itopo, &iflat, &ird_mask,
                                   &tres_, &sres_, &iza, &ite_, &its_, &ird_spertm,
                                   &coupledT_, &coupledS_, &coriolis_on,
@@ -608,7 +608,7 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     FNAME(init)(&nloc, &mloc, &lloc, &nmlglob,
                 &xminloc, &xmaxloc, &yminloc, &ymaxloc,
                 &alphaT,&alphaS,
-                &ih, &vmix_,
+                &ih, &vmix_, &tap,
                 &perio, landm,
                 taux, tauy, tatm, emip, spert);
 

--- a/src/ocean/THCM.H
+++ b/src/ocean/THCM.H
@@ -472,7 +472,7 @@ private:
     bool compSalInt_;
 
     //! mixing?
-    int vmixGLB_;
+    int vmix_;
 
     //! sres_=0: non-restoring salt forcing => integral condition in A and f
     int sres_;

--- a/src/ocean/global.F90
+++ b/src/ocean/global.F90
@@ -22,7 +22,6 @@ module m_global
   use m_usr, only :                          &
        zmin, zmax,                           &
        hdim, qz,                             &
-       rho_mixing,                           &
        itopo, flat, rd_mask,                 &
        coupled_T, coupled_S,                 &
        TRES, SRES, iza, ite, its, rd_spertm, &
@@ -67,7 +66,6 @@ contains
   !! subdomains will only use xmin,xmax,ymin and ymax)
   subroutine initialize(a_n,a_m,a_l,&
        a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz,&
-       a_rho_mixing,&
        a_periodic,a_itopo,a_flat,a_rd_mask,&
        a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm,&
        a_coupled_T, a_coupled_S, a_coriolis_on,&
@@ -78,7 +76,6 @@ contains
 
     integer(c_int) :: a_n,a_m,a_l
     real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz
-    integer(c_int) :: a_rho_mixing
     integer(c_int) :: a_periodic,a_itopo,a_flat,a_rd_mask
     integer(c_int) :: a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm
     integer(c_int) :: a_coupled_T, a_coupled_S, a_coriolis_on
@@ -90,12 +87,6 @@ contains
     ymax  = a_ymax
     hdim  = a_hdim
     qz    = a_qz
-
-    if (a_rho_mixing.ne.0) then
-       rho_mixing = .true.
-    else
-       rho_mixing = .false.
-    end if
 
     if (a_periodic .ne. 0) then
        periodic   = .true.

--- a/src/ocean/global.F90
+++ b/src/ocean/global.F90
@@ -28,8 +28,6 @@ module m_global
        forcing_type,                         &
        rowintcon, f99, t0, s0
 
-  use m_atm, only : Ooa, suno
-
   implicit none
 
   integer, parameter :: nf   =  4

--- a/src/ocean/global.F90
+++ b/src/ocean/global.F90
@@ -22,7 +22,7 @@ module m_global
   use m_usr, only :                          &
        zmin, zmax,                           &
        hdim, qz,                             &
-       ih, vmix_GLB, tap, rho_mixing,        &
+       vmix_GLB, tap, rho_mixing,            &
        itopo, flat, rd_mask,                 &
        coupled_T, coupled_S,                 &
        TRES, SRES, iza, ite, its, rd_spertm, &
@@ -67,7 +67,7 @@ contains
   !! subdomains will only use xmin,xmax,ymin and ymax)
   subroutine initialize(a_n,a_m,a_l,&
        a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz,&
-       a_ih,a_vmix_GLB,a_tap,a_rho_mixing,&
+       a_vmix_GLB,a_tap,a_rho_mixing,&
        a_periodic,a_itopo,a_flat,a_rd_mask,&
        a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm,&
        a_coupled_T, a_coupled_S, a_coriolis_on,&
@@ -78,7 +78,7 @@ contains
 
     integer(c_int) :: a_n,a_m,a_l
     real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz
-    integer(c_int) :: a_ih,a_vmix_GLB,a_tap,a_rho_mixing
+    integer(c_int) :: a_vmix_GLB,a_tap,a_rho_mixing
     integer(c_int) :: a_periodic,a_itopo,a_flat,a_rd_mask
     integer(c_int) :: a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm
     integer(c_int) :: a_coupled_T, a_coupled_S, a_coriolis_on
@@ -91,7 +91,6 @@ contains
     hdim  = a_hdim
     qz    = a_qz
 
-    ih       = a_ih
     vmix_GLB = a_vmix_GLB
     tap      = a_tap
     if (a_rho_mixing.ne.0) then

--- a/src/ocean/global.F90
+++ b/src/ocean/global.F90
@@ -22,7 +22,7 @@ module m_global
   use m_usr, only :                          &
        zmin, zmax,                           &
        hdim, qz,                             &
-       tap, rho_mixing,                      &
+       rho_mixing,                           &
        itopo, flat, rd_mask,                 &
        coupled_T, coupled_S,                 &
        TRES, SRES, iza, ite, its, rd_spertm, &
@@ -67,7 +67,7 @@ contains
   !! subdomains will only use xmin,xmax,ymin and ymax)
   subroutine initialize(a_n,a_m,a_l,&
        a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz,&
-       a_tap,a_rho_mixing,&
+       a_rho_mixing,&
        a_periodic,a_itopo,a_flat,a_rd_mask,&
        a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm,&
        a_coupled_T, a_coupled_S, a_coriolis_on,&
@@ -78,7 +78,7 @@ contains
 
     integer(c_int) :: a_n,a_m,a_l
     real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz
-    integer(c_int) :: a_tap,a_rho_mixing
+    integer(c_int) :: a_rho_mixing
     integer(c_int) :: a_periodic,a_itopo,a_flat,a_rd_mask
     integer(c_int) :: a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm
     integer(c_int) :: a_coupled_T, a_coupled_S, a_coriolis_on
@@ -91,7 +91,6 @@ contains
     hdim  = a_hdim
     qz    = a_qz
 
-    tap      = a_tap
     if (a_rho_mixing.ne.0) then
        rho_mixing = .true.
     else

--- a/src/ocean/global.F90
+++ b/src/ocean/global.F90
@@ -22,7 +22,7 @@ module m_global
   use m_usr, only :                          &
        zmin, zmax,                           &
        hdim, qz,                             &
-       alphaT, alphaS,                       &
+       alphaS,                               &
        ih, vmix_GLB, tap, rho_mixing,        &
        itopo, flat, rd_mask,                 &
        coupled_T, coupled_S,                 &
@@ -68,7 +68,7 @@ contains
   !! subdomains will only use xmin,xmax,ymin and ymax)
   subroutine initialize(a_n,a_m,a_l,&
        a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz,&
-       a_alphaT,a_alphaS,&
+       a_alphaS,&
        a_ih,a_vmix_GLB,a_tap,a_rho_mixing,&
        a_periodic,a_itopo,a_flat,a_rd_mask,&
        a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm,&
@@ -80,7 +80,7 @@ contains
 
     integer(c_int) :: a_n,a_m,a_l
     real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz
-    real(c_double) :: a_alphaT, a_alphaS
+    real(c_double) :: a_alphaS
     integer(c_int) :: a_ih,a_vmix_GLB,a_tap,a_rho_mixing
     integer(c_int) :: a_periodic,a_itopo,a_flat,a_rd_mask
     integer(c_int) :: a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm
@@ -94,7 +94,6 @@ contains
     hdim  = a_hdim
     qz    = a_qz
 
-    alphaT   = a_alphaT
     alphaS   = a_alphaS
 
     ih       = a_ih

--- a/src/ocean/global.F90
+++ b/src/ocean/global.F90
@@ -22,7 +22,6 @@ module m_global
   use m_usr, only :                          &
        zmin, zmax,                           &
        hdim, qz,                             &
-       alphaS,                               &
        ih, vmix_GLB, tap, rho_mixing,        &
        itopo, flat, rd_mask,                 &
        coupled_T, coupled_S,                 &
@@ -68,7 +67,6 @@ contains
   !! subdomains will only use xmin,xmax,ymin and ymax)
   subroutine initialize(a_n,a_m,a_l,&
        a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz,&
-       a_alphaS,&
        a_ih,a_vmix_GLB,a_tap,a_rho_mixing,&
        a_periodic,a_itopo,a_flat,a_rd_mask,&
        a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm,&
@@ -80,7 +78,6 @@ contains
 
     integer(c_int) :: a_n,a_m,a_l
     real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz
-    real(c_double) :: a_alphaS
     integer(c_int) :: a_ih,a_vmix_GLB,a_tap,a_rho_mixing
     integer(c_int) :: a_periodic,a_itopo,a_flat,a_rd_mask
     integer(c_int) :: a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm
@@ -93,8 +90,6 @@ contains
     ymax  = a_ymax
     hdim  = a_hdim
     qz    = a_qz
-
-    alphaS   = a_alphaS
 
     ih       = a_ih
     vmix_GLB = a_vmix_GLB

--- a/src/ocean/global.F90
+++ b/src/ocean/global.F90
@@ -25,7 +25,7 @@ module m_global
        itopo, flat, rd_mask,                 &
        coupled_T, coupled_S,                 &
        TRES, SRES, iza, ite, its, rd_spertm, &
-       coriolis_on, forcing_type,            &
+       forcing_type,                         &
        rowintcon, f99, t0, s0
 
   use m_atm, only : Ooa, suno
@@ -68,7 +68,7 @@ contains
        a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz,&
        a_periodic,a_itopo,a_flat,a_rd_mask,&
        a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm,&
-       a_coupled_T, a_coupled_S, a_coriolis_on,&
+       a_coupled_T, a_coupled_S,&
        a_forcing_type)
 
     use, intrinsic :: iso_c_binding
@@ -78,7 +78,7 @@ contains
     real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz
     integer(c_int) :: a_periodic,a_itopo,a_flat,a_rd_mask
     integer(c_int) :: a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm
-    integer(c_int) :: a_coupled_T, a_coupled_S, a_coriolis_on
+    integer(c_int) :: a_coupled_T, a_coupled_S
     integer(c_int) :: a_forcing_type
 
     xmin  = a_xmin
@@ -115,7 +115,6 @@ contains
     else
        rd_spertm = .false.
     end if
-    coriolis_on = a_coriolis_on
     forcing_type = a_forcing_type
 
     !========= I-EMIC coupling  ================================

--- a/src/ocean/global.F90
+++ b/src/ocean/global.F90
@@ -22,7 +22,7 @@ module m_global
   use m_usr, only :                          &
        zmin, zmax,                           &
        hdim, qz,                             &
-       vmix_GLB, tap, rho_mixing,            &
+       tap, rho_mixing,                      &
        itopo, flat, rd_mask,                 &
        coupled_T, coupled_S,                 &
        TRES, SRES, iza, ite, its, rd_spertm, &
@@ -67,7 +67,7 @@ contains
   !! subdomains will only use xmin,xmax,ymin and ymax)
   subroutine initialize(a_n,a_m,a_l,&
        a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz,&
-       a_vmix_GLB,a_tap,a_rho_mixing,&
+       a_tap,a_rho_mixing,&
        a_periodic,a_itopo,a_flat,a_rd_mask,&
        a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm,&
        a_coupled_T, a_coupled_S, a_coriolis_on,&
@@ -78,7 +78,7 @@ contains
 
     integer(c_int) :: a_n,a_m,a_l
     real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax,a_hdim,a_qz
-    integer(c_int) :: a_vmix_GLB,a_tap,a_rho_mixing
+    integer(c_int) :: a_tap,a_rho_mixing
     integer(c_int) :: a_periodic,a_itopo,a_flat,a_rd_mask
     integer(c_int) :: a_TRES,a_SRES,a_iza,a_ite,a_its,a_rd_spertm
     integer(c_int) :: a_coupled_T, a_coupled_S, a_coriolis_on
@@ -91,7 +91,6 @@ contains
     hdim  = a_hdim
     qz    = a_qz
 
-    vmix_GLB = a_vmix_GLB
     tap      = a_tap
     if (a_rho_mixing.ne.0) then
        rho_mixing = .true.

--- a/src/ocean/mix_imp.f
+++ b/src/ocean/mix_imp.f
@@ -64,17 +64,17 @@ Call structure DSM and FDJS
 
       real time0, time1
 
-      if (vmix_GLB.eq.0) then
+      if (vmix.eq.0) then
          vmix_flag = 0
          vmix_diff = 1
          vmix_out  = 1
          vmix_fix  = 1
-      else if (vmix_GLB.eq.1) then
+      else if (vmix.eq.1) then
          vmix_flag = 1
          vmix_diff = 1
          vmix_out  = 1
          vmix_fix  = 1
-      else if (vmix_GLB.eq.2) then
+      else if (vmix.eq.2) then
          vmix_flag = 2
          vmix_diff = 1
          vmix_out  = 1
@@ -117,7 +117,7 @@ Call structure DSM and FDJS
 !include 'usr.com'
 !include 'mix.com'
 
-      if (vmix_GLB.eq.0) then
+      if (vmix.eq.0) then
          par(MIXP)   =  0.0
          par(P_VC)   =  0.0
          par(ALPC)   =  1.0

--- a/src/ocean/mix_imp.f
+++ b/src/ocean/mix_imp.f
@@ -708,7 +708,7 @@ Call structure DSM and FDJS
       elseif (tap == 2) then
          tpr = 0.5 * (1.0 - tanh( (absslp-delta)/sd  ) )
 !     *     De Niet et al
-      elseif (tap ==3) then
+      elseif (tap == 3) then
          if     ( (absslp.lt.delta-sd).and.(drdz.lt.0.0) ) then
             tpr = 1.0
          elseif ( (absslp.ge.delta-sd).and.(absslp.lt.delta)

--- a/src/ocean/usr.F90
+++ b/src/ocean/usr.F90
@@ -54,7 +54,7 @@ module m_usr
   !     These are set in initialize in global.F90
 
   integer :: ih         = 0       ! inhomogeneous (equatorial) mixing
-  integer :: vmix_GLB   = 1       ! mixing flag
+  integer :: vmix       = 1       ! mixing flag
   integer :: tap        = 1       ! neutral physics taper, 1: Gerdes
   ! et al., 2: Danabasoglu & McWilliams,
   ! 3: De Niet et al.

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -6,7 +6,7 @@
 SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
      a_xmin,a_xmax,a_ymin,a_ymax,&
      a_alphaT,a_alphaS,&
-     a_ih,a_vmix,a_tap,&
+     a_ih,a_vmix,a_tap,a_rho_mixing,&
      a_periodic,a_landm,&
      a_taux,a_tauy,a_tatm,a_emip,a_spert)
 
@@ -22,7 +22,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   integer(c_int) :: a_n,a_m,a_l,a_nmlglob
   real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax
   real(c_double) :: a_alphaT, a_alphaS
-  integer(c_int) :: a_ih, a_vmix, a_tap
+  integer(c_int) :: a_ih, a_vmix, a_tap, a_rho_mixing
   integer(c_int) :: a_periodic
   integer(c_int), dimension((a_n+2)*(a_m+2)*(a_l+2)) :: a_landm
   real(c_double), dimension(a_n*a_m) :: a_taux,a_tauy
@@ -47,6 +47,12 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   ih      = a_ih
   vmix    = a_vmix
   tap     = a_tap
+
+  if (a_rho_mixing.ne.0) then
+     rho_mixing = .true.
+  else
+     rho_mixing = .false.
+  end if
 
   !initialize atmos coefficients
   qdim = 0.01

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -6,7 +6,7 @@
 SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
      a_xmin,a_xmax,a_ymin,a_ymax,&
      a_alphaT,a_alphaS,&
-     a_ih,&
+     a_ih,a_vmix,&
      a_periodic,a_landm,&
      a_taux,a_tauy,a_tatm,a_emip,a_spert)
 
@@ -22,7 +22,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   integer(c_int) :: a_n,a_m,a_l,a_nmlglob
   real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax
   real(c_double) :: a_alphaT, a_alphaS
-  integer(c_int) :: a_ih
+  integer(c_int) :: a_ih, a_vmix
   integer(c_int) :: a_periodic
   integer(c_int), dimension((a_n+2)*(a_m+2)*(a_l+2)) :: a_landm
   real(c_double), dimension(a_n*a_m) :: a_taux,a_tauy
@@ -45,6 +45,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   alphaS  = a_alphaS
 
   ih      = a_ih
+  vmix_GLB= a_vmix
 
   !initialize atmos coefficients
   qdim = 0.01

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -5,6 +5,7 @@
 !! bounds of the domain (formerly set in usr.com)
 SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
      a_xmin,a_xmax,a_ymin,a_ymax,&
+     a_alphaT,&
      a_periodic,a_landm,&
      a_taux,a_tauy,a_tatm,a_emip,a_spert)
 
@@ -19,6 +20,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
 
   integer(c_int) :: a_n,a_m,a_l,a_nmlglob
   real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax
+  real(c_double) :: a_alphaT
   integer(c_int) :: a_periodic
   integer(c_int), dimension((a_n+2)*(a_m+2)*(a_l+2)) :: a_landm
   real(c_double), dimension(a_n*a_m) :: a_taux,a_tauy
@@ -36,6 +38,8 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   xmax    = a_xmax
   ymin    = a_ymin
   ymax    = a_ymax
+
+  alphaT  = a_alphaT
 
   !initialize atmos coefficients
   qdim = 0.01

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -7,6 +7,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
      a_xmin,a_xmax,a_ymin,a_ymax,&
      a_alphaT,a_alphaS,&
      a_ih,a_vmix,a_tap,a_rho_mixing,&
+     a_coriolis_on,&
      a_periodic,a_landm,&
      a_taux,a_tauy,a_tatm,a_emip,a_spert)
 
@@ -23,6 +24,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax
   real(c_double) :: a_alphaT, a_alphaS
   integer(c_int) :: a_ih, a_vmix, a_tap, a_rho_mixing
+  integer(c_int) :: a_coriolis_on
   integer(c_int) :: a_periodic
   integer(c_int), dimension((a_n+2)*(a_m+2)*(a_l+2)) :: a_landm
   real(c_double), dimension(a_n*a_m) :: a_taux,a_tauy
@@ -53,6 +55,8 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   else
      rho_mixing = .false.
   end if
+
+  coriolis_on = a_coriolis_on
 
   !initialize atmos coefficients
   qdim = 0.01

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -6,6 +6,7 @@
 SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
      a_xmin,a_xmax,a_ymin,a_ymax,&
      a_alphaT,a_alphaS,&
+     a_ih,&
      a_periodic,a_landm,&
      a_taux,a_tauy,a_tatm,a_emip,a_spert)
 
@@ -21,6 +22,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   integer(c_int) :: a_n,a_m,a_l,a_nmlglob
   real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax
   real(c_double) :: a_alphaT, a_alphaS
+  integer(c_int) :: a_ih
   integer(c_int) :: a_periodic
   integer(c_int), dimension((a_n+2)*(a_m+2)*(a_l+2)) :: a_landm
   real(c_double), dimension(a_n*a_m) :: a_taux,a_tauy
@@ -41,6 +43,8 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
 
   alphaT  = a_alphaT
   alphaS  = a_alphaS
+
+  ih      = a_ih
 
   !initialize atmos coefficients
   qdim = 0.01

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -45,7 +45,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   alphaS  = a_alphaS
 
   ih      = a_ih
-  vmix_GLB= a_vmix
+  vmix    = a_vmix
 
   !initialize atmos coefficients
   qdim = 0.01

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -6,7 +6,7 @@
 SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
      a_xmin,a_xmax,a_ymin,a_ymax,&
      a_alphaT,a_alphaS,&
-     a_ih,a_vmix,&
+     a_ih,a_vmix,a_tap,&
      a_periodic,a_landm,&
      a_taux,a_tauy,a_tatm,a_emip,a_spert)
 
@@ -22,7 +22,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   integer(c_int) :: a_n,a_m,a_l,a_nmlglob
   real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax
   real(c_double) :: a_alphaT, a_alphaS
-  integer(c_int) :: a_ih, a_vmix
+  integer(c_int) :: a_ih, a_vmix, a_tap
   integer(c_int) :: a_periodic
   integer(c_int), dimension((a_n+2)*(a_m+2)*(a_l+2)) :: a_landm
   real(c_double), dimension(a_n*a_m) :: a_taux,a_tauy
@@ -46,6 +46,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
 
   ih      = a_ih
   vmix    = a_vmix
+  tap     = a_tap
 
   !initialize atmos coefficients
   qdim = 0.01

--- a/src/ocean/usrc.F90
+++ b/src/ocean/usrc.F90
@@ -5,7 +5,7 @@
 !! bounds of the domain (formerly set in usr.com)
 SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
      a_xmin,a_xmax,a_ymin,a_ymax,&
-     a_alphaT,&
+     a_alphaT,a_alphaS,&
      a_periodic,a_landm,&
      a_taux,a_tauy,a_tatm,a_emip,a_spert)
 
@@ -20,7 +20,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
 
   integer(c_int) :: a_n,a_m,a_l,a_nmlglob
   real(c_double) :: a_xmin,a_xmax,a_ymin,a_ymax
-  real(c_double) :: a_alphaT
+  real(c_double) :: a_alphaT, a_alphaS
   integer(c_int) :: a_periodic
   integer(c_int), dimension((a_n+2)*(a_m+2)*(a_l+2)) :: a_landm
   real(c_double), dimension(a_n*a_m) :: a_taux,a_tauy
@@ -40,6 +40,7 @@ SUBROUTINE init(a_n,a_m,a_l,a_nmlglob,&
   ymax    = a_ymax
 
   alphaT  = a_alphaT
+  alphaS  = a_alphaS
 
   !initialize atmos coefficients
   qdim = 0.01


### PR DESCRIPTION
Refs #93 

This moves the variables that are not needed in global to usr. Maybe some functions can also be (re)moved to clean up even more variables.