### PR TITLE
Add documentation for some parameters

### DIFF
--- a/src/continuation/Continuation.H
+++ b/src/continuation/Continuation.H
@@ -9,6 +9,8 @@
 #include "GlobalDefinitions.H"
 #include "Utils.H"
 
+#include "Teuchos_StandardParameterEntryValidators.hpp"
+
 #include <math.h> // pow(), sqrt()
 #include <ctime>
 #include <iomanip>
@@ -1366,7 +1368,15 @@ getDefaultInitParameters()
     result.get("corrector residual test", 'D');
     result.get("initial tangent type", 'E');
     result.get("print important vectors", false);
-    result.get("post processing", "at every point");
+
+    Teuchos::RCP<Teuchos::StringToIntegralParameterEntryValidator<int>> post_processing_validator(
+        new Teuchos::StringToIntegralParameterEntryValidator<int>(
+            Teuchos::tuple<std::string> ("at every point", "at final point"), "post processing"));
+
+    result.set("post processing", "at every point",
+               "When to call post processing as implemented by the Model",
+               post_processing_validator);
+
     result.get("predictor bound", 1e3);
 
     std::stringstream destID;

--- a/src/main/run_ocean.C
+++ b/src/main/run_ocean.C
@@ -23,6 +23,31 @@ void runOceanModel(RCP<Epetra_Comm> Comm);
 //------------------------------------------------------------------
 int main(int argc, char **argv)
 {
+    Teuchos::CommandLineProcessor clp(false);
+    clp.setDocString("This program performs an ocean-only run of I-EMIC\n");
+
+    bool describe_parameters = false;
+    clp.setOption("describe-parameters", "disable-describe-parameters", &describe_parameters,
+                  "Describe all possible parameter values");
+
+    Teuchos::CommandLineProcessor::EParseCommandLineReturn ret = clp.parse(argc, argv);
+
+    if (ret == Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED)
+        return 0;
+    if (ret != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL)
+        return -1;
+
+    if (describe_parameters)
+    {
+        Teuchos::ParameterList::PrintOptions opts;
+        opts.showDoc(true);
+        Teuchos::ParameterList params;
+        params.sublist("Ocean") = Ocean::getDefaultInitParameters();
+        params.sublist("Continuation") = Continuation<RCP<Ocean>>::getDefaultInitParameters();
+        params.print(std::cout, opts);
+        return 0;
+    }
+
     // Initialize the environment:
     //  - MPI
     //  - output files

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -16,6 +16,7 @@
 #include <vector>
 #include <algorithm>
 
+#include "Teuchos_StandardParameterEntryValidators.hpp"
 #include "Teuchos_StandardCatchMacros.hpp"
 
 #include "Epetra_Comm.h"
@@ -2590,18 +2591,28 @@ THCM::getDefaultInitParameters()
     Teuchos::ParameterList result = getDefaultParameters();
     result.setName("THCM Default Init Parameters");
 
-    result.get("Problem Description","Unnamed");
+    result.set("Problem Description", "Unnamed",
+               "A descriptive name to identify the settings");
 
-    result.get("Global Grid-Size n", 16);
-    result.get("Global Grid-Size m", 16);
-    result.get("Global Grid-Size l", 16);
+    result.set("Global Grid-Size n", 16,
+               "Global number of grid point in the x-direction (west-east).");
+    result.set("Global Grid-Size m", 16,
+               "Global number of grid point in the y-direction (south-north).");
+    result.set("Global Grid-Size l", 16,
+               "Global number of grid point in the z-direction (depth).");
+
+    Teuchos::RCP<Teuchos::EnhancedNumberValidator<double> > longitude_validator(
+        new Teuchos::EnhancedNumberValidator<double>(-360.0, 360.0));
+
+    Teuchos::RCP<Teuchos::EnhancedNumberValidator<double> > latitude_validator(
+        new Teuchos::EnhancedNumberValidator<double>(-90.0, 90.0));
 
     // default: north atlantic
-    result.get("Global Bound xmin", 286.0);
-    result.get("Global Bound xmax", 350.0);
-    result.get("Global Bound ymin", 10.0);
-    result.get("Global Bound ymax", 74.0);
-    result.get("Periodic", false);
+    result.set("Global Bound xmin", 286.0, "Western domain bound", longitude_validator);
+    result.set("Global Bound xmax", 350.0, "Eastern domain bound", longitude_validator);
+    result.set("Global Bound ymin", 10.0, "Southern domain bound", latitude_validator);
+    result.set("Global Bound ymax", 74.0, "Northern domain bound", latitude_validator);
+    result.set("Periodic", false, "Periodic boundary conditions in the x-direction");
 
     result.get("Depth hdim", 4000.0);
     result.get("Grid Stretching qz", 1.0);


### PR DESCRIPTION
Displaying the documentation is still work in progress.

It seems like there is no validator for chars, so either we have to implement that, or we should start using strings.

Continuation parameters can only be validated after all models have been converted to the new parameter list style (so we can check that they are valid parameters and that they can be modified during the run).