### PR TITLE
Eliminate unused Starting Parameters

### DIFF
--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -1748,8 +1748,7 @@ int THCM::par2int(std::string const &label)
     int TEMP   = 17; int BIOT   = 18; int COMB   = 19; int ARCL   = 20;
     int NLES   = 21; int IFRICB = 22; int CONT   = 23; int ENER   = 24;
     int ALPC   = 25; int CMPR   = 26; int FPER   = 27; int SPER   = 28;
-    int MKAP   = 29; int SPL2   = 30; int EXPO   = 31; int SEAS   = 32;
-    int SEASW  = 33; int SEAST  = 34; int SEASS  = 35; int MASS   = 36;
+    int MKAP   = 29; int SPL2   = 30;
 
     if      (label == "Time")                            return TIME;
     else if (label == "AL_T")                            return AL_T;
@@ -1782,12 +1781,6 @@ int THCM::par2int(std::string const &label)
     else if (label == "Flux Perturbation")               return FPER;
     else if (label == "MKAP")                            return MKAP;
     else if (label == "SPL2")                            return SPL2;
-    else if (label == "Exponent")                        return EXPO;
-    else if (label == "Seasonal Forcing")                return SEAS;// combination of T,S and Wind
-    else if (label == "Seasonal Forcing (Temperature)")  return SEAST;
-    else if (label == "Seasonal Forcing (Salinity)")     return SEASS;
-    else if (label == "Seasonal Forcing (Wind)")         return SEASW;
-    else if (label == "Mass")                            return MASS;
 
     return -1;
 }
@@ -1807,8 +1800,7 @@ std::string const THCM::int2par(int index)
     int TEMP   = 17; int BIOT   = 18; int COMB   = 19; int ARCL   = 20;
     int NLES   = 21; int IFRICB = 22; int CONT   = 23; int ENER   = 24;
     int ALPC   = 25; int CMPR   = 26; int FPER   = 27; int SPER   = 28;
-    int MKAP   = 29; int SPL2   = 30; int EXPO   = 31; int SEAS   = 32;
-    int SEASW  = 33; int SEAST  = 34; int SEASS  = 35; int MASS   = 36;
+    int MKAP   = 29; int SPL2   = 30;
 
     if      (index==TIME)   label = "Time";
     else if (index==AL_T)   label = "AL_T";
@@ -1841,12 +1833,6 @@ std::string const THCM::int2par(int index)
     else if (index==SPL2)   label = "SPL2";
     else if (index==FPER)   label = "Flux Perturbation";
     else if (index==SPER)   label = "Salinity Perturbation";
-    else if (index==EXPO)   label = "Exponent";
-    else if (index==SEAS)   label = "Seasonal Forcing";
-    else if (index==SEASW)  label = "Seasonal Forcing (Wind)";
-    else if (index==SEAST)  label = "Seasonal Forcing (Temperature)";
-    else if (index==SEASS)  label = "Seasonal Forcing (Salinity)";
-    else if (index==MASS)   label = "Mass";
     else
     {
         ERROR("Parameter index is invalid!",__FILE__,__LINE__);

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -771,17 +771,17 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     }
 
     for (auto& pair : paramList_.sublist("Starting Parameters")) {
+        std::string key = pair.first;
         double val = pair.second.getValue(&val);
-        if (!std::isnan(val)) setParameter(pair.first, val);
+        if (!std::isnan(val)) setParameter(key, val);
+        else {
+            getParameter(key, val);
+            paramList_.sublist("Starting Parameters").remove(key);
+            paramList_.sublist("Starting Parameters").get(key, val);
+        }
     }
 
     params = paramList_;
-
-    for (auto& pair : params.sublist("Starting Parameters")) {
-        double val;
-        getParameter(pair.first, val);
-        paramList_.sublist("Starting Parameters").set(pair.first, val);
-    }
 }
 
 //=============================================================================

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -776,6 +776,12 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
     }
 
     params = paramList_;
+
+    for (auto& pair : params.sublist("Starting Parameters")) {
+        double val;
+        getParameter(pair.first, val);
+        paramList_.sublist("Starting Parameters").set(pair.first, val);
+    }
 }
 
 //=============================================================================

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -1130,7 +1130,6 @@ bool THCM::evaluate(const Epetra_Vector& soln,
                 // reconstruct the diagonal matrix B
                 int lid = standardMap_->LID(assemblyMap_->GID(i));
                 double mass_param = 1.0;
-                this->getParameter("Mass", mass_param);
                 (*localDiagB_)[lid] = coB_[i] * mass_param;
             } //not a ghost?
         } //i-loop over rows
@@ -2655,7 +2654,8 @@ THCM::getDefaultParameters()
     Teuchos::ParameterList result("THCM Default Parameters");
 
     Teuchos::ParameterList& startParams = result.sublist("Starting Parameters");
-    for (int i=0; i<= _NPAR_ + _NPAR_TRILI; i++)
+    // Start from 1 since 0 (Time) isn't settable
+    for (int i=1; i<= _NPAR_; i++)
     {
         std::string label = int2par(i);
         startParams.get(label, std::numeric_limits<double>::quiet_NaN());

--- a/src/ocean/THCM.C
+++ b/src/ocean/THCM.C
@@ -770,15 +770,18 @@ THCM::THCM(Teuchos::ParameterList& params, Teuchos::RCP<Epetra_Comm> comm) :
         colScaling_->PutScalar(1.0);
     }
 
-    for (auto& pair : paramList_.sublist("Starting Parameters")) {
+    Teuchos::ParameterList tmpList = paramList_.sublist("Starting Parameters");
+
+    for (auto& pair : tmpList) {
         std::string key = pair.first;
         double val = pair.second.getValue(&val);
         if (!std::isnan(val)) setParameter(key, val);
         else {
             getParameter(key, val);
             paramList_.sublist("Starting Parameters").remove(key);
-            paramList_.sublist("Starting Parameters").get(key, val);
         }
+
+        paramList_.sublist("Starting Parameters").get(key, val);
     }
 
     params = paramList_;

--- a/src/tests/TestDefinitions.C
+++ b/src/tests/TestDefinitions.C
@@ -210,7 +210,7 @@ generalCheckParameterListAgainstDefaultAndOverrides(
                 validVal = overrideList.getEntry(key);
             } else {
                 validVal = defaultedList.getEntry(key);
-                if (!value.isDefault() && !(isNaN(validVal) && allowNanChanges)) {
+                if (!value.isDefault()) {
                     result &= ::testing::AssertionFailure() << "expected " << name << " to be defaulted\n";
                 }
             }

--- a/src/tests/TestDefinitions.C
+++ b/src/tests/TestDefinitions.C
@@ -104,16 +104,19 @@ checkUnusedParameterEntry(
     return ::testing::AssertionSuccess();
 }
 
+bool isNaN(const Teuchos::ParameterEntry& param)
+{ return param.isType<double>() && std::isnan(param.getValue<double>(nullptr)); }
+
 ::testing::AssertionResult
 compareParameterEntries(
     const std::string& paramName, const Teuchos::ParameterEntry& param,
-    const Teuchos::ParameterEntry& validParam
+    const Teuchos::ParameterEntry& validParam, bool allowNanChanges = false
     )
 {
-    if (param.isType<double>() && validParam.isType<double>()) {
-        if (std::isnan(param.getValue<double>(nullptr)) && std::isnan(validParam.getValue<double>(nullptr))) {
-            return ::testing::AssertionSuccess() << "NaNs treated as equal";
-        }
+    if (isNaN(validParam) && isNaN(param)) {
+        return ::testing::AssertionSuccess() << "NaNs treated as equal";
+    } else if (isNaN(validParam) && param.isType<double>() && allowNanChanges) {
+        return ::testing::AssertionSuccess() << "NaNs allowed to change";
     }
 
     if (param == validParam) {
@@ -160,10 +163,13 @@ checkParameters(
     return result;
 }
 
+namespace {
 ::testing::AssertionResult
-checkParameterListAgainstDefaultAndOverrides(
-    const Teuchos::ParameterList& checkList, const Teuchos::ParameterList& defaultList,
-    const Teuchos::ParameterList& overrideList
+generalCheckParameterListAgainstDefaultAndOverrides(
+    const Teuchos::ParameterList& checkList,
+    const Teuchos::ParameterList& defaultList,
+    const Teuchos::ParameterList& overrideList,
+    bool allowNanChanges
     )
 {
     auto result = ::testing::AssertionSuccess();
@@ -190,7 +196,12 @@ checkParameterListAgainstDefaultAndOverrides(
                 sublist = overrideList.sublist(key);
             }
 
-            result &= checkParameterListAgainstDefaultAndOverrides(checkList.sublist(key), defaultedList.sublist(key), sublist);
+            result &= generalCheckParameterListAgainstDefaultAndOverrides(
+                    checkList.sublist(key),
+                    defaultedList.sublist(key),
+                    sublist,
+                    allowNanChanges
+                    );
         } else {
             std::string name = checkList.name() + "->" + key;
 
@@ -199,12 +210,12 @@ checkParameterListAgainstDefaultAndOverrides(
                 validVal = overrideList.getEntry(key);
             } else {
                 validVal = defaultedList.getEntry(key);
-                if (!value.isDefault()) {
+                if (!value.isDefault() && !(isNaN(validVal) && allowNanChanges)) {
                     result &= ::testing::AssertionFailure() << "expected " << name << " to be defaulted\n";
                 }
             }
 
-            result &= compareParameterEntries(name, value, validVal);
+            result &= compareParameterEntries(name, value, validVal, allowNanChanges);
         }
     }
 
@@ -218,4 +229,23 @@ checkParameterListAgainstDefaultAndOverrides(
     }
 
     return result;
+}
+}
+
+::testing::AssertionResult
+checkParameterListAgainstDefaultAndOverrides(
+    const Teuchos::ParameterList& checkList,
+    const Teuchos::ParameterList& defaultList,
+    const Teuchos::ParameterList& overrideList
+    )
+{ return generalCheckParameterListAgainstDefaultAndOverrides(checkList, defaultList, overrideList, false);
+}
+
+::testing::AssertionResult
+checkParameterListAgainstDefaultAndOverridesAllowNanChanges(
+    const Teuchos::ParameterList& checkList,
+    const Teuchos::ParameterList& defaultList,
+    const Teuchos::ParameterList& overrideList
+    )
+{ return generalCheckParameterListAgainstDefaultAndOverrides(checkList, defaultList, overrideList, true);
 }

--- a/src/tests/TestDefinitions.H
+++ b/src/tests/TestDefinitions.H
@@ -149,4 +149,12 @@ checkParameterListAgainstDefaultAndOverrides
 , const Teuchos::ParameterList& defaultList
 , const Teuchos::ParameterList& overrideList = Teuchos::ParameterList()
 );
+
+// Like above, but allows values whose defaults are NaN to change.
+::testing::AssertionResult
+checkParameterListAgainstDefaultAndOverridesAllowNanChanges
+( const Teuchos::ParameterList& checkList
+, const Teuchos::ParameterList& defaultList
+, const Teuchos::ParameterList& overrideList = Teuchos::ParameterList()
+);
 #endif

--- a/src/tests/test_parameterlist.C
+++ b/src/tests/test_parameterlist.C
@@ -307,7 +307,7 @@ TEST(THCMParameterList, DefaultInitialization)
 
         // Check that every parameter in oceanParams matches defaultParams, and
         // check that they're all reported as defaulted
-        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(thcmParams, defaultParams));
+        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(thcmParams, defaultParams));
         EXPECT_TRUE(checkParameters(thcmParams, checkDefaultParameterEntry));
 
         // Check that every parameter reported by Ocean matches defaultParams
@@ -354,7 +354,7 @@ TEST(THCMParameterList, Initialization)
 
         // Check that every entry in oceanParams corresponds to the value in
         // startParams, missing entries are compared against defaultParams
-        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(thcmParams, defaultParams, startParams));
+        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(thcmParams, defaultParams, startParams));
 
         // Check that every entry reported by Ocean corresponds to the value in
         // startParams, missing entries are compared against defaultParams
@@ -395,7 +395,7 @@ TEST(OceanParameterList, DefaultInitialization)
 
         // Check that every parameter in oceanParams matches defaultParams, and
         // check that they're all reported as defaulted
-        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(oceanParams, defaultParams));
+        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(oceanParams, defaultParams));
         EXPECT_TRUE(checkParameters(oceanParams, checkDefaultParameterEntry));
 
         // Check that every parameter reported by Ocean matches defaultParams
@@ -441,7 +441,7 @@ TEST(OceanParameterList, Initialization)
 
         // Check that every entry in oceanParams corresponds to the value in
         // startParams, missing entries are compared against defaultParams
-        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(oceanParams, defaultParams, startParams));
+        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(oceanParams, defaultParams, startParams));
 
         // Check that every entry reported by Ocean corresponds to the value in
         // startParams, missing entries are compared against defaultParams

--- a/src/tests/test_parameterlist.C
+++ b/src/tests/test_parameterlist.C
@@ -249,6 +249,38 @@ TEST(ParameterList, MatchOverriddenSublist)
     EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(list, defaultList, overrideList));
 }
 
+TEST(ParameterList, CheckNanChangeFailure)
+{
+    Teuchos::ParameterList defaultList("Default List");
+
+    defaultList.get("Test", std::numeric_limits<double>::quiet_NaN());
+
+    Teuchos::ParameterList list("Test List");
+    list.set("Test", 15.0);
+
+    // checkParameterListAgainstDefaultAndOverrides(list1, list2, list3) checks
+    // that every element in list1 matches the elements in list3. If list3 is
+    // missing an element it is matched with list2 and must be marked as
+    // defaulted
+    EXPECT_FALSE(checkParameterListAgainstDefaultAndOverrides(list, defaultList));
+}
+
+TEST(ParameterList, CheckNanChangeSuccess)
+{
+    Teuchos::ParameterList defaultList("Default List");
+
+    defaultList.get("Test", std::numeric_limits<double>::quiet_NaN());
+
+    Teuchos::ParameterList list("Test List");
+    list.set("Test", 15.0);
+
+    // checkParameterListAgainstDefaultAndOverrides(list1, list2, list3) checks
+    // that every element in list1 matches the elements in list3. If list3 is
+    // missing an element it is matched with list2 and must be marked as
+    // defaulted
+    EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(list, defaultList));
+}
+
 //------------------------------------------------------------------
 TEST(THCMParameterList, DefaultInitialization)
 {

--- a/src/tests/test_parameterlist.C
+++ b/src/tests/test_parameterlist.C
@@ -310,10 +310,8 @@ TEST(THCMParameterList, DefaultInitialization)
         EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(thcmParams, defaultParams));
         EXPECT_TRUE(checkParameters(thcmParams, checkDefaultParameterEntry));
 
-        // Check that every parameter reported by Ocean matches defaultParams,
-        // and check that they're all reported as defaulted
-        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(currentParams, defaultParams));
-        EXPECT_TRUE(checkParameters(currentParams, checkDefaultParameterEntry));
+        // Check that every parameter reported by Ocean matches defaultParams
+        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(currentParams, defaultParams));
     }
     catch (...)
     {
@@ -358,15 +356,9 @@ TEST(THCMParameterList, Initialization)
         // startParams, missing entries are compared against defaultParams
         EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(thcmParams, defaultParams, startParams));
 
-        // Check that every parameter is used
-        //
-        // This MUST be before checkParameterListAgainstDefaultAndOverrides
-        // because it marks everything as used...
-        EXPECT_TRUE(checkParameters(currentParams, checkUsedParameterEntry));
-
         // Check that every entry reported by Ocean corresponds to the value in
         // startParams, missing entries are compared against defaultParams
-        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(currentParams, defaultParams, startParams));
+        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(currentParams, defaultParams, startParams));
     }
     catch (...)
     {
@@ -406,10 +398,8 @@ TEST(OceanParameterList, DefaultInitialization)
         EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(oceanParams, defaultParams));
         EXPECT_TRUE(checkParameters(oceanParams, checkDefaultParameterEntry));
 
-        // Check that every parameter reported by Ocean matches defaultParams,
-        // and check that they're all reported as defaulted
-        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(currentParams, defaultParams));
-        EXPECT_TRUE(checkParameters(currentParams, checkDefaultParameterEntry));
+        // Check that every parameter reported by Ocean matches defaultParams
+        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(currentParams, defaultParams));
     }
     catch (...)
     {
@@ -453,15 +443,9 @@ TEST(OceanParameterList, Initialization)
         // startParams, missing entries are compared against defaultParams
         EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(oceanParams, defaultParams, startParams));
 
-        // Check that every parameter is used
-        //
-        // This MUST be before checkParameterListAgainstDefaultAndOverrides
-        // because it marks everything as used...
-        EXPECT_TRUE(checkParameters(currentParams, checkUsedParameterEntry));
-
         // Check that every entry reported by Ocean corresponds to the value in
         // startParams, missing entries are compared against defaultParams
-        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverrides(currentParams, defaultParams, startParams));
+        EXPECT_TRUE(checkParameterListAgainstDefaultAndOverridesAllowNanChanges(currentParams, defaultParams, startParams));
     }
     catch (...)
     {

--- a/src/tests/test_parameterlist.C
+++ b/src/tests/test_parameterlist.C
@@ -272,7 +272,7 @@ TEST(ParameterList, CheckNanChangeSuccess)
     defaultList.get("Test", std::numeric_limits<double>::quiet_NaN());
 
     Teuchos::ParameterList list("Test List");
-    list.set("Test", 15.0);
+    list.get("Test", 15.0);
 
     // checkParameterListAgainstDefaultAndOverrides(list1, list2, list3) checks
     // that every element in list1 matches the elements in list3. If list3 is

--- a/src/trios/THCMdefs.H
+++ b/src/trios/THCMdefs.H
@@ -24,9 +24,6 @@
 // number of parameters currently used in THCM (excluding our own params 
 // "Time" and "Exponent", which shouldn't be passed to THCM directly).   
 #define _NPAR_ 30
-// we added time (0, doesn't count) and some more parameters.
-// these are not passed on to THCM, though.
-#define _NPAR_TRILI 6
 // number of unknowns
 #define _NUN_ 6
 // number of grid neighbours


### PR DESCRIPTION
This drops the unsettable parameters from the `Starting Parameters` list in THCM. It also updates the `THCM::paramList_` to include the Fortran initialised values, plus changes to the `ParameterList` test to deal with these changes.