### PR TITLE
Draft implementation of the position mapping in the Fortran code.

### DIFF
--- a/src/trios/TRIOS_Domain.C
+++ b/src/trios/TRIOS_Domain.C
@@ -67,6 +67,16 @@ namespace TRIOS
                 else
                     return z;
             };
+
+        dfdz_ = [&](double z)
+            {
+                double ch = cosh(qz_ * (z+1));
+                if (qz_ > 1.0)
+                    return qz_ / (tanh(qz_) * ch * ch);
+                else
+                    return 1.0 + (1.0 - qz_) * (1.0 - (2.0 * z));
+            };
+
     }
 
     // Destructor
@@ -507,6 +517,78 @@ namespace TRIOS
         delete [] row_ranks;
         return new_comm;
 #endif //}
+    }
+
+    double Domain::getXpos(double x) const
+    {
+        if (x < 0 || x >= n) {
+            ERROR("Index out of bounds!",__FILE__,__LINE__);
+        }
+
+        double dx = (xmax-xmin)/n;
+        return x*dx + xmin;
+    }
+
+    double Domain::getYpos(double y) const
+    {
+        if (y < 0 || y >= m) {
+            ERROR("Index out of bounds!",__FILE__,__LINE__);
+        }
+
+        double dy = (ymax-ymin)/m;
+        return y*dy + ymin;
+    }
+
+    double Domain::getZpos(double z) const
+    {
+        if (z < 0 || z >= l) {
+            ERROR("Index out of bounds!",__FILE__,__LINE__);
+        }
+
+        double dz, ze, dfzT;
+
+        dz = (zmax-zmin)/l;
+        ze = z*dz + zmin;
+        dfzT = dfdz_(ze);
+
+        return dz * dfzT * hdim;
+    }
+
+    double Domain::getXposEdge(int x) const
+    { return getXpos(x); }
+
+    double Domain::getYposEdge(int y) const
+    { return getYpos(y); }
+
+    double Domain::getZposEdge(int z) const
+    { return getZpos(z); }
+
+    double Domain::getXposCenter(int x) const
+    {
+        if (x == 0) {
+            ERROR("Center not defined at index 0!",__FILE__,__LINE__);
+        }
+
+        return getXpos(x - 0.5);
+    }
+
+    double Domain::getYposCenter(int y) const
+    {
+        double dy = (ymax-ymin)/m;
+
+        if (y == 0) return getYposCenter(1) - dy;
+        else if (y == m+1) return getYposCenter(m) + dy;
+
+        return getYpos(y - 0.5);
+    }
+
+    double Domain::getZposCenter(int z) const
+    {
+        if (z == 0) {
+            ERROR("Center not defined at index 0!",__FILE__,__LINE__);
+        }
+
+        return getZpos(z - 0.5);
     }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/src/trios/TRIOS_Domain.H
+++ b/src/trios/TRIOS_Domain.H
@@ -231,6 +231,16 @@ namespace TRIOS {
         double Zmax() const {return zmax;}
         //@}
 
+        //@{ get physical position of grid index
+        double getXposEdge(int x) const;
+        double getYposEdge(int y) const;
+        double getZposEdge(int z) const;
+
+        double getXposCenter(int x) const;
+        double getYposCenter(int y) const;
+        double getZposCenter(int z) const;
+        //@}
+
         //! returns true if the given local index 'li' is on a
         //! ghost-node. 'nun' is specified to indicate the unknowns
         //! per grid point
@@ -285,6 +295,11 @@ namespace TRIOS {
         int Standard2Solve(const Epetra_CrsMatrix& source, Epetra_CrsMatrix& target) const;
 
     protected:
+        //@{ get physical position of grid position
+        double getXpos(double x) const;
+        double getYpos(double y) const;
+        double getZpos(double z) const;
+        //@}
 
         //! communicator object
         Teuchos::RCP<Epetra_Comm> comm;
@@ -347,6 +362,8 @@ namespace TRIOS {
 
         //! vertical grid stretching function
         std::function<double(double)> fz_;
+
+        std::function<double(double)> dfdz_;
 
         //! number of unknowns per grid cell
         int dof_;


### PR DESCRIPTION
This reimplements the Fortran code [here](https://github.com/nlesc-smcm/i-emic/blob/master/src/ocean/grid.F90#L19-L95) in TRIOS_Domain, which lets us compute the "real" position (both at the edges and center) from grid indices for https://github.com/nlesc-smcm/i-emic/issues/66.

That would let us obsolete `grid.F90` and do the initialisation for all the Fortran grid arrays from C++, as a starting point for moving the initialisation out of Fortran.

Right now the code follows the Fortran exactly, but this leads to some unidiomatic C++ as some of the Fortran arrays start at 0 and some at 1 (the center index for cell 1 in the fortran arrays points to the center of logical cell 0, see the `- 0.5` in the index calculation). We could normalise that to index 0 pointing to the center of logical cell 0 by simply using `+ 0.5` and keep the Fortran code the same by just translating from that 0-indexed approach to the current Fortran layout when the arrays get initialised from C++.

Either way is fine with me, but I don't know what your opinions are.

(Also, obviously still needs tests that check that the C++ version matches the Fortran initialisation, but I'll do that after we decide whether or not to change the C++ code...)