### PR TITLE
fix source of lookup error

### DIFF
--- a/src/ocean/Ocean.C
+++ b/src/ocean/Ocean.C
@@ -2312,7 +2312,7 @@ const Teuchos::ParameterList& Ocean::getParameters()
 
 void Ocean::setParameters(Teuchos::ParameterList& newParams)
 {
-    newParams.validateParameters(getDefaultParameters());
+    newParams.validateParameters(getDefaultInitParameters());
     thcm_->setParameters(newParams.sublist("THCM"));
     params_.setParameters(newParams);
 }


### PR DESCRIPTION
it seems better to validate against the init than against getDefaultPArameters (that one is almost empty)
this fixes a problem where the validation goes wrong if "Belos Solver" sublist is present in the newParams